### PR TITLE
Switch music-metadata to Blob-streaming, with slipping post-headers

### DIFF
--- a/src/lib/store/index.svelte.ts
+++ b/src/lib/store/index.svelte.ts
@@ -1,7 +1,7 @@
 import { converters } from "$lib/converters";
 import { error, log } from "$lib/logger";
 import { VertFile } from "$lib/types";
-import { parseBuffer, selectCover } from "music-metadata";
+import { parseBlob, selectCover } from "music-metadata";
 import { writable } from "svelte/store";
 import { addDialog } from "./DialogProvider";
 
@@ -33,7 +33,7 @@ class Files {
 		try {
 			if (isAudio) {
 				// try to get the thumbnail from the audio via music-metadata
-				const {common} = await parseBuffer(new Uint8Array(await file.file.arrayBuffer()));
+				const {common} = await parseBlob(file.file, {skipPostHeaders: true});
 				const cover = selectCover(common.picture);
 				if (cover) {
 					const blob = new Blob(


### PR DESCRIPTION
This PR switched back to Blob-streaming mode, but with the difference `skipPostHeaders` is enabled.
`skipPostHeaders`  disable music-metadata tries to parse ID3v1 headers appearing at the very end of the MP3, which require to stream the entire MP3.

Switching to this mode is 30% faster on Firefox compared to current mode  (converting the full Blob to a buffer).
Note that id3v1 headers cannot hold any album art.