### PR TITLE
fix: Fix FLIP animation overflow error

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -131,7 +131,7 @@
 
 <!-- FIXME: if user resizes between desktop/mobile, highlight of page disappears (only shows on original size) -->
 <div
-	class="flex flex-col min-h-screen h-full"
+	class="flex flex-col min-h-screen h-full w-full overflow-x-hidden"
 	ondrop={dropFiles}
 	ondragenter={(e) => handleDrag(e, true)}
 	ondragover={(e) => handleDrag(e, true)}


### PR DESCRIPTION
## Before

https://github.com/user-attachments/assets/0643581d-9286-4394-b7fd-06642ec5c79f


FLIP animation error on mobile.

## After


https://github.com/user-attachments/assets/bbb51078-a15a-4fbc-98ec-62cd4343dd91

