### PR TITLE
docs: update docker instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ If using nginx, you can use the [nginx.conf](./nginx.conf) file as a starting po
 
 Clone the repository, then build a Docker image with:
 ```shell
-$ docker build -t VERT-sh/vert \
+$ docker build -t vert-sh/vert \
 	--build-arg PUB_ENV=production \
 	--build-arg PUB_HOSTNAME=vert.sh \
 	--build-arg PUB_PLAUSIBLE_URL=https://plausible.example.com .
@@ -67,10 +67,25 @@ $ docker build -t VERT-sh/vert \
 
 You can then run it by using:
 ```shell
-$ docker run --restart unless-stopped -p 3000:3000 -d --name "vert" VERT-sh/vert
+$ docker run -d \
+	--restart unless-stopped \
+	-p 3000:80 \
+	--name "vert" \
+	vert-sh/vert
 ```
 
-We also have a `docker-compose.yml` file available. Use `docker compose up` if you want to start the stack, or `docker compose down` to bring it down. You can pass `--build` to `docker compose up` to rebuild the Docker image (useful if you've changed any of the environment variables) as well as `-d` to start it in detached mode. You can read more about Docker Compose in general [here](https://docs.docker.com/compose/intro/compose-application-model/).
+This will run the image in dettached mode, restart the container unless it is manually stopped, map 3000/tcp (host) to 80/tcp (container), name the container `vert` and use the previously built image.
+
+We also have a [`docker-compose.yml`](./docker-compose.yml) file available. Use `docker compose up` if you want to start the stack, or `docker compose down` to bring it down. You can pass `--build` to `docker compose up` to rebuild the Docker image (useful if you've changed any of the environment variables) as well as `-d` to start it in detached mode. You can read more about Docker Compose in general [here](https://docs.docker.com/compose/intro/compose-application-model/).
+
+While there's an image you can pull instead of having to clone this repository and build the image yourself, you will not be able to update any of the environment variables (e.g. `PUB_PLAUSIBLE_URL`) as they're baked directly into the image and not obtained during runtime. If you're okay with this, you can simply run this command instead:
+```shell
+$ docker run -d \
+	--restart unless-stopped \
+	-p 3000:80 \
+	--name "vert" \
+	ghcr.io/vert-sh/vert:latest
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -74,11 +74,14 @@ $ docker run -d \
 	vert-sh/vert
 ```
 
-This will run the image in dettached mode, restart the container unless it is manually stopped, map 3000/tcp (host) to 80/tcp (container), name the container `vert` and use the previously built image.
+This will do the following:
+- Use the previously built image as the container `vert`, in detached mode
+- Continuously restart the container until manually stopped
+- Map `3000/tcp` (host) to `80/tcp` (container)
 
 We also have a [`docker-compose.yml`](./docker-compose.yml) file available. Use `docker compose up` if you want to start the stack, or `docker compose down` to bring it down. You can pass `--build` to `docker compose up` to rebuild the Docker image (useful if you've changed any of the environment variables) as well as `-d` to start it in detached mode. You can read more about Docker Compose in general [here](https://docs.docker.com/compose/intro/compose-application-model/).
 
-While there's an image you can pull instead of having to clone this repository and build the image yourself, you will not be able to update any of the environment variables (e.g. `PUB_PLAUSIBLE_URL`) as they're baked directly into the image and not obtained during runtime. If you're okay with this, you can simply run this command instead:
+While there's an image you can pull instead of cloning the repo and building the image yourself, you will not be able to update any of the environment variables (e.g. `PUB_PLAUSIBLE_URL`) as they're baked directly into the image and not obtained during runtime. If you're okay with this, you can simply run this command instead:
 ```shell
 $ docker run -d \
 	--restart unless-stopped \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   vert:
     container_name: vert
-    image: VERT-sh/vert:latest
+    image: vert-sh/vert:latest
     environment:
       - PUB_HOSTNAME=${PUB_HOSTNAME:-vert.sh}
       - PUB_PLAUSIBLE_URL=${PUB_PLAUSIBLE_URL:-https://plausible.example.com}


### PR DESCRIPTION
* Update build instructions to use fully lowercase image tag
  - Also updated Docker Compose file
* Map 3000/tcp (host) to 80/tcp (container) instead
* Add `docker run` command explanation
* Add pre-built image instructions
