### PR TITLE
Fix: Use typeof IconType for icon property from lucide-svelte

### DIFF
--- a/src/lib/components/layout/Navbar/Base.svelte
+++ b/src/lib/components/layout/Navbar/Base.svelte
@@ -16,6 +16,7 @@
 		SettingsIcon,
 		SunIcon,
 		UploadIcon,
+		type Icon as IconType,
 	} from "lucide-svelte";
 	import { quintOut } from "svelte/easing";
 	import Panel from "../../visual/Panel.svelte";
@@ -28,7 +29,7 @@
 			name: string;
 			url: string;
 			activeMatch: (pathname: string) => boolean;
-			icon: any;
+			icon: typeof IconType;
 			badge?: number;
 		}[]
 	>([


### PR DESCRIPTION
This PR fixes the typing for the `icon` property in `Base.svelte`.

Previously, the `icon` property was typed as `any`. This change updates it to `typeof IconType` from `@lucide/svelte` to provide better type safety and align with the official `lucide-svelte` documentation.

**Motivation:**

Using `any` bypasses TypeScript's type checking, potentially leading to runtime errors and making the codebase harder to maintain. By using the specific `IconType`, we ensure that only valid Lucide Svelte icon components are passed, improving developer experience and code robustness.

**Reference:**

As recommended by the `lucide-svelte` documentation: [Lucide Svelte - TypeScript Usage](https://lucide.dev/guide/packages/lucide-svelte)

**Changes:**

- Updated the type definition for `icon` from `any` to `typeof IconType`.