### PR TITLE
fix: empty file name fallback

### DIFF
--- a/src/lib/store/index.svelte.ts
+++ b/src/lib/store/index.svelte.ts
@@ -239,7 +239,7 @@ class Files {
 		const url = URL.createObjectURL(blob);
 
 		const settings = JSON.parse(localStorage.getItem("settings") ?? "{}");
-		const filenameFormat = settings.filenameFormat ?? "VERT_%name%";
+		const filenameFormat = settings.filenameFormat || "VERT_%name%";
 
 		const format = (name: string) => {
 			const date = new Date().toISOString();

--- a/src/lib/types/file.svelte.ts
+++ b/src/lib/types/file.svelte.ts
@@ -91,7 +91,7 @@ export class VertFile {
 		if (!to.startsWith(".")) to = `.${to}`;
 
 		const settings = JSON.parse(localStorage.getItem("settings") ?? "{}");
-		const filenameFormat = settings.filenameFormat ?? "VERT_%name%";
+		const filenameFormat = settings.filenameFormat || "VERT_%name%";
 
 		const format = (name: string) => {
 			const date = new Date().toISOString();


### PR DESCRIPTION
### Summary
Fix empty file name fallback for single and bulk downloads

### Problem
If the file name input is left empty, files are downloaded with empty names, leaving the extension to become the file name and the browser defaulting the extension to .txt

### Solution
Use the logical OR `||` instead of the nullish coalescing `??` operator, which ensures that empty strings fall back to the default filename
