### PR TITLE
docs: update DOCKER.md

### DIFF
--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -34,7 +34,7 @@ This will do the following:
 - Continuously restart the container until manually stopped
 - Map `3000/tcp` (host) to `80/tcp` (container)
 
-We also have a [`docker-compose.yml`](./docker-compose.yml) file available. Use `docker compose up` if you want to start the stack, or `docker compose down` to bring it down. You can pass `--build` to `docker compose up` to rebuild the Docker image (useful if you've changed any of the environment variables) as well as `-d` to start it in detached mode. You can read more about Docker Compose in general [here](https://docs.docker.com/compose/intro/compose-application-model/).
+We also have a [`docker-compose.yml`](/docker-compose.yml) file available. Use `docker compose up` if you want to start the stack, or `docker compose down` to bring it down. You can pass `--build` to `docker compose up` to rebuild the Docker image (useful if you've changed any of the environment variables) as well as `-d` to start it in detached mode. You can read more about Docker Compose in general [here](https://docs.docker.com/compose/intro/compose-application-model/).
 
 ### Using an image from the GitHub Container Registry
 While there's an image you can pull instead of cloning the repo and building the image yourself, you will not be able to update any of the environment variables (e.g. `PUB_PLAUSIBLE_URL`) as they're baked directly into the image and not obtained during runtime. If you're okay with this, you can simply run this command instead:


### PR DESCRIPTION
The docker-compose.yml link for this doc doesn't work as it seems like the compose file has been moved to the root. This PR adjusts the path to point to the correct one.