### PR TITLE
Remove unused `environment` section from the Docker Compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,24 +2,15 @@ services:
   vert:
     container_name: vert
     image: ghcr.io/vert-sh/vert:latest
-    environment:
-      - PUB_HOSTNAME=${PUB_HOSTNAME:-vert.sh}
-      - PUB_PLAUSIBLE_URL=${PUB_PLAUSIBLE_URL:-https://plausible.example.com}
-      - PUB_ENV=${PUB_ENV:-production}
-      - PORT=${PORT:-3000}
-      - PUB_VERTD_URL=${PUB_VERTD_URL:-https://vertd.vert.sh}
-      - PUB_DONATION_URL=${PUB_DONATION_URL:-https://donations.vert.sh}
-      - PUB_STRIPE_KEY=${PUB_STRIPE_KEY:-pk_live_51RDVmAGSxPVad6bQwzVNnbc28nlmzA30krLWk1fefCMpUPiSRPkavMMbGqa8A3lUaOCMlsUEVy2CWDYg0ip3aPpL00ZJlsMkf2}
     build:
       context: .
       args:
-        PUB_HOSTNAME: ${PUB_HOSTNAME:-vert.sh}
-        PUB_PLAUSIBLE_URL: ${PUB_PLAUSIBLE_URL:-https://plausible.example.com}
+        PUB_HOSTNAME: ${PUB_HOSTNAME:-localhost:5173}
+        PUB_PLAUSIBLE_URL: ${PUB_PLAUSIBLE_URL:-}
         PUB_ENV: ${PUB_ENV:-production}
-        PUB_VERTD_URL: ${PUB_VERTD_URL:-https://vertd.vert.sh}
+        PUB_VERTD_URL: ${PUB_VERTD_URL:-}
         PUB_DONATION_URL: ${PUB_DONATION_URL:-https://donations.vert.sh}
         PUB_STRIPE_KEY: ${PUB_STRIPE_KEY:-pk_live_51RDVmAGSxPVad6bQwzVNnbc28nlmzA30krLWk1fefCMpUPiSRPkavMMbGqa8A3lUaOCMlsUEVy2CWDYg0ip3aPpL00ZJlsMkf2}
-
     restart: unless-stopped
     ports:
       - ${PORT:-3000}:80


### PR DESCRIPTION
VERT uses `$env/static` for environment variables, so none of these are being used during runtime. They should only be passed to Docker during container build time.