### PR TITLE
Add `EXPOSE` instruction to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ RUN bun run build
 
 FROM nginx:stable-alpine
 
+EXPOSE 80/tcp
+
 COPY ./nginx/default.conf /etc/nginx/conf.d/default.conf
 
 COPY --from=builder /app/build /usr/share/nginx/html


### PR DESCRIPTION
While `nginx:stable-alpine` already exposes 80/tcp by default (visible with `docker image inspect`), I figured it was still worth adding so that the port which VERT uses when running inside a container is a bit more clear.