### PR TITLE
Add Docker container health-checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,3 +29,6 @@ FROM nginx:stable-alpine
 COPY ./nginx/default.conf /etc/nginx/conf.d/default.conf
 
 COPY --from=builder /app/build /usr/share/nginx/html
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD curl --fail --silent --output /dev/null http://localhost || exit 1

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,5 +1,6 @@
 server {
     listen 80;
+    listen [::]:80;
     server_name vert;
 
     root /usr/share/nginx/html;


### PR DESCRIPTION
Adds a default health-check to the Docker container using `curl`:
```dockerfile
HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
    CMD curl --fail --silent --output /dev/null http://localhost || exit 1
```

Running `docker ps` will show whether the container is healthy under the status column:
```shell
$ docker ps
CONTAINER ID   IMAGE                         COMMAND                  CREATED          STATUS                    PORTS                                     NAMES
6495213a13a5   ghcr.io/vert-sh/vert:latest   "/docker-entrypoint.…"   10 seconds ago   Up 10 seconds (healthy)   0.0.0.0:3000->80/tcp, [::]:3000->80/tcp   vert
```

Or, alternatively, you can use `docker inspect`:
```shell
$ docker inspect --format='{{json .State.Health}}' vert | jq
{
  "Status": "healthy",
  "FailingStreak": 0,
  "Log": [
    {
      "Start": "2025-10-16T10:36:59.32758589-04:00",
      "End": "2025-10-16T10:36:59.361606634-04:00",
      "ExitCode": 0,
      "Output": ""
    }
  ]
}
```