### PR TITLE
i18n: Complete missing translations for zh-CN and zh-TW

### DIFF
--- a/messages/zh-Hans.json
+++ b/messages/zh-Hans.json
@@ -47,6 +47,12 @@
 		}
 	},
 	"convert": {
+		"zip_file": {
+			"extracting": "检测到 ZIP 压缩包：{filename}",
+			"extracted": "从 {filename} 中提取了 {extract_count} 个文件。{ignore_count} 个项目被忽略。",
+			"extract_error": "提取 {filename} 时出错：{error}"
+		},
+		"large_file_warning": "由于浏览器/设备限制，此文件大于 {limit}GB，视频转音频功能已禁用。我们建议使用 Firefox 或 Safari 处理此大小的文件，因为它们的限制较少。",
 		"external_warning": {
 			"title": "外部服务器警告",
 			"text": "如果你选择转换为视频格式，这些文件将被上传到外部服务器进行转换。是否继续？",
@@ -183,7 +189,15 @@
 			"total_size": "总大小",
 			"files_cached_label": "已缓存文件",
 			"cache_cleared": "缓存已成功清除！",
-			"cache_clear_error": "清除缓存失败。"
+			"cache_clear_error": "清除缓存失败。",
+			"site_data_title": "网站数据管理",
+			"site_data_description": "清除所有网站数据，包括设置和缓存文件，将 VERT 重置为默认状态并重新加载页面。",
+			"clear_all_data": "清除所有网站数据",
+			"clear_all_data_confirm_title": "清除所有网站数据？",
+			"clear_all_data_confirm": "这将重置所有设置和缓存，然后重新加载页面。此操作无法撤消。",
+			"clear_all_data_cancel": "取消",
+			"all_data_cleared": "所有网站数据已清除！正在重新加载页面...",
+			"all_data_clear_error": "清除所有网站数据失败。"
 		},
 		"language": {
 			"title": "语言",
@@ -248,8 +262,10 @@
 			"cancel": "取消转换 {file} 时出错：{message}",
 			"magick": "Magick worker 出错，图片转换可能无法正常工作。",
 			"ffmpeg": "加载 ffmpeg 时出错，某些功能可能无法工作。",
+			"pandoc": "加载 Pandoc worker 时出错，文档转换可能无法正常工作。",
 			"no_audio": "未找到音频流。",
-			"invalid_rate": "指定的采样率无效：{rate}Hz"
+			"invalid_rate": "指定的采样率无效：{rate}Hz",
+			"file_too_large": "此文件超过 {limit}GB 浏览器/设备限制。请尝试使用 Firefox 或 Safari 转换此大文件，它们通常具有更高的限制。"
 		}
 	},
 	"privacy": {

--- a/messages/zh-Hant.json
+++ b/messages/zh-Hant.json
@@ -47,6 +47,12 @@
 		}
 	},
 	"convert": {
+		"zip_file": {
+			"extracting": "偵測到 ZIP 壓縮檔：{filename}",
+			"extracted": "從 {filename} 中提取了 {extract_count} 個檔案。{ignore_count} 個項目被忽略。",
+			"extract_error": "提取 {filename} 時出錯：{error}"
+		},
+		"large_file_warning": "由於瀏覽器/裝置限制，此檔案大於 {limit}GB，影片轉音訊功能已停用。我們建議使用 Firefox 或 Safari 處理此大小的檔案，因為它們的限制較少。",
 		"external_warning": {
 			"title": "外部伺服器警告",
 			"text": "如果你選擇轉換為影片格式，這些檔案將被上傳到外部伺服器進行轉換。是否繼續？",
@@ -183,7 +189,15 @@
 			"total_size": "總大小",
 			"files_cached_label": "已快取檔案",
 			"cache_cleared": "快取已成功清除！",
-			"cache_clear_error": "清除快取失敗。"
+			"cache_clear_error": "清除快取失敗。",
+			"site_data_title": "網站資料管理",
+			"site_data_description": "清除所有網站資料，包括設定和快取檔案，將 VERT 重置為預設狀態並重新載入頁面。",
+			"clear_all_data": "清除所有網站資料",
+			"clear_all_data_confirm_title": "清除所有網站資料？",
+			"clear_all_data_confirm": "這將重置所有設定和快取，然後重新載入頁面。此操作無法復原。",
+			"clear_all_data_cancel": "取消",
+			"all_data_cleared": "所有網站資料已清除！正在重新載入頁面...",
+			"all_data_clear_error": "清除所有網站資料失敗。"
 		},
 		"language": {
 			"title": "語言",
@@ -248,8 +262,10 @@
 			"cancel": "取消轉換 {file} 時出錯：{message}",
 			"magick": "Magick worker 出錯，圖片轉換可能無法正常運作。",
 			"ffmpeg": "載入 ffmpeg 時出錯，某些功能可能無法運作。",
+			"pandoc": "載入 Pandoc worker 時出錯，文件轉換可能無法正常運作。",
 			"no_audio": "未找到音訊串流。",
-			"invalid_rate": "指定的取樣率無效：{rate}Hz"
+			"invalid_rate": "指定的取樣率無效：{rate}Hz",
+			"file_too_large": "此檔案超過 {limit}GB 瀏覽器/裝置限制。請嘗試使用 Firefox 或 Safari 轉換此大型檔案，它們通常具有較高的限制。"
 		}
 	},
 	"privacy": {


### PR DESCRIPTION
adds missing translations for Simplified Chinese (zh-CN) and Traditional Chinese (zh-TW) to bring them in sync with the latest English version.

## Changes
- ✅ Added `zip_file` section with extraction messages
- ✅ Added `large_file_warning` for browser/device limitations
- ✅ Added site data management section in privacy settings
  - `site_data_title`
  - `site_data_description`
  - `clear_all_data` and related confirmation messages
- ✅ Added missing error messages in `workers.errors`
  - `pandoc` worker error message
  - `file_too_large` error message
