### PR TITLE
fix: correct MIME type for PWA manifest icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ Thumbs.db
 # Vite
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# IDE
+.idea

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -10,12 +10,12 @@
 		{
 			"src": "lettermark.jpg",
 			"sizes": "192x192",
-			"type": "image/png"
+			"type": "image/jpeg"
 		},
 		{
 			"src": "lettermark.jpg",
 			"sizes": "512x512",
-			"type": "image/png"
+			"type": "image/jpeg"
 		}
 	]
 }


### PR DESCRIPTION
The manifest.json was incorrectly specifying 'image/png' as the type for lettermark.jpg icon files. This commit fixes the MIME type to 'image/jpeg' to match the actual file format, ensuring proper PWA standards compliance and preventing potential browser compatibility issues.

Also adds .idea/ to .gitignore to exclude JetBrains IDE configuration.