### PR TITLE
fix: add security headers to nginx configurations

### DIFF
--- a/nginx/default-ssl.conf
+++ b/nginx/default-ssl.conf
@@ -18,6 +18,13 @@ server {
 
     client_max_body_size 10M;
 
+    # Security headers
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
     location / {
         try_files $uri $uri/ /index.html;
     }

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -8,6 +8,12 @@ server {
 
     client_max_body_size 10M;
 
+    # Security headers
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
+
     location / {
         try_files $uri $uri/ /index.html;
     }


### PR DESCRIPTION

- Add X-Frame-Options to prevent clickjacking attacks
- Add X-Content-Type-Options to prevent MIME-type sniffing
- Add Referrer-Policy for privacy protection
- Add Permissions-Policy to restrict unnecessary browser features
- Add HSTS header to SSL config for enforcing HTTPS connections

These headers are critical security measures that protect against
common web vulnerabilities and follow OWASP security best practices.
