### PR TITLE
fix: install curl in Docker image for healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,8 @@ RUN bun run build
 
 FROM nginx:stable-alpine
 
+RUN apk add --no-cache curl
+
 EXPOSE 80/tcp
 
 COPY ./nginx/default.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
The HEALTHCHECK command in the Dockerfile was using curl, but curl is not available by default in the nginx:stable-alpine base image. This caused the health checks to always fail.

This commit adds curl installation using apk to ensure the healthcheck works correctly.