### PR TITLE
style: Remove centered text from upload page

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -135,14 +135,14 @@
 		<div
 			class="flex items-center h-auto gap-12 md:gap-24 md:flex-row flex-col"
 		>
-			<div class="flex-grow px-6 w-full md:text-left">
+			<div class="flex-grow w-full md:text-left">
 				<h1
-					class="text-4xl md:p-0 md:text-6xl flex-wrap tracking-tight leading-tight md:leading-[72px] mb-4 md:mb-6"
+					class="text-4xl md:p-0 px-6 md:text-6xl flex-wrap tracking-tight leading-tight md:leading-[72px] mb-4 md:mb-6"
 				>
 					{m["upload.title"]()}
 				</h1>
 				<p
-					class="font-normal md:p-0 text-lg md:text-xl text-black text-muted dynadark:text-muted"
+					class="font-normal px-6 md:p-0 text-lg md:text-xl text-black text-muted dynadark:text-muted"
 				>
 					{m["upload.subtitle"]()}
 				</p>


### PR DESCRIPTION
Change title, status and supported formats text in category cards from centered to left-aligned (leading edge). Also removes a comma as a separator since the point at the beginning of a file format separates file types already.

Centered text blocks negatively impact readability and usability, particularly on mobile where the format lists become visually cluttered.

Following established UI conventions (as seen in iOS 26's removal of centered text blocks), users can scan content more easily when each line begins at a consistent starting point. The card headers and status indicators can remain centered where appropriate, but the format lists benefit from leading-edge alignment.

<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/64e875ec-3635-4fd7-a7b9-72aaba185464" width="400" /></td>
    <td><img src="https://github.com/user-attachments/assets/22232a69-21d9-46d1-ac67-83b42038fd4f" width="400" /></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/bba7af55-61d2-40b3-aeb6-673431c1e02a" width="400" /></td>
    <td><img src="https://github.com/user-attachments/assets/d3a1e7c8-0a89-45b2-9197-c1112b8d12d2" width="400" /></td>
  </tr>
</table>
