### PR TITLE
feat: MCP server for file conversion

### DIFF
--- a/mcp/.gitignore
+++ b/mcp/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,0 +1,1309 @@
+{
+	"name": "@vert-sh/mcp-server",
+	"version": "0.1.0",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "@vert-sh/mcp-server",
+			"version": "0.1.0",
+			"license": "AGPL-3.0-only",
+			"dependencies": {
+				"@imagemagick/magick-wasm": "0.0.38",
+				"@modelcontextprotocol/sdk": "1.27.0",
+				"byte-data": "19.0.1",
+				"riff-file": "1.0.3",
+				"which": "^3.0.0",
+				"yazl": "3.3.1",
+				"zod": "^3.25.0"
+			},
+			"bin": {
+				"mcp-server": "dist/index.js"
+			},
+			"devDependencies": {
+				"@types/node": "^22",
+				"@types/which": "^3",
+				"@types/yazl": "^2",
+				"typescript": "^5.9.3"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@hono/node-server": {
+			"version": "1.19.9",
+			"resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
+			"integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.14.1"
+			},
+			"peerDependencies": {
+				"hono": "^4"
+			}
+		},
+		"node_modules/@imagemagick/magick-wasm": {
+			"version": "0.0.38",
+			"resolved": "https://registry.npmjs.org/@imagemagick/magick-wasm/-/magick-wasm-0.0.38.tgz",
+			"integrity": "sha512-xg3q6ZMqUADyyy0h/1IndT9DUWUXY5lRhevF2WB+AYvphJ5yraH+R0IGO7H7DFnLSMrJ6zsxEbXfOnhNfark9w==",
+			"license": "Apache-2.0"
+		},
+		"node_modules/@modelcontextprotocol/sdk": {
+			"version": "1.27.0",
+			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.0.tgz",
+			"integrity": "sha512-qOdO524oPMkUsOJTrsH9vz/HN3B5pKyW+9zIW51A9kDMVe7ON70drz1ouoyoyOcfzc+oxhkQ6jWmbyKnlWmYqA==",
+			"license": "MIT",
+			"dependencies": {
+				"@hono/node-server": "^1.19.9",
+				"ajv": "^8.17.1",
+				"ajv-formats": "^3.0.1",
+				"content-type": "^1.0.5",
+				"cors": "^2.8.5",
+				"cross-spawn": "^7.0.5",
+				"eventsource": "^3.0.2",
+				"eventsource-parser": "^3.0.0",
+				"express": "^5.2.1",
+				"express-rate-limit": "^8.2.1",
+				"hono": "^4.11.4",
+				"jose": "^6.1.3",
+				"json-schema-typed": "^8.0.2",
+				"pkce-challenge": "^5.0.0",
+				"raw-body": "^3.0.0",
+				"zod": "^3.25 || ^4.0",
+				"zod-to-json-schema": "^3.25.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@cfworker/json-schema": "^4.1.1",
+				"zod": "^3.25 || ^4.0"
+			},
+			"peerDependenciesMeta": {
+				"@cfworker/json-schema": {
+					"optional": true
+				},
+				"zod": {
+					"optional": false
+				}
+			}
+		},
+		"node_modules/@types/node": {
+			"version": "22.19.11",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
+			"integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.21.0"
+			}
+		},
+		"node_modules/@types/which": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/which/-/which-3.0.4.tgz",
+			"integrity": "sha512-liyfuo/106JdlgSchJzXEQCVArk0CvevqPote8F8HgWgJ3dRCcTHgJIsLDuee0kxk/mhbInzIZk3QWSZJ8R+2w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/yazl": {
+			"version": "2.4.6",
+			"resolved": "https://registry.npmjs.org/@types/yazl/-/yazl-2.4.6.tgz",
+			"integrity": "sha512-/ifFjQtcKaoZOjl5NNCQRR0fAKafB3Foxd7J/WvFPTMea46zekapcR30uzkwIkKAAuq5T6d0dkwz754RFH27hg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/accepts": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+			"integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+			"license": "MIT",
+			"dependencies": {
+				"mime-types": "^3.0.0",
+				"negotiator": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/ajv": {
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/ajv-formats": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+			"integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+			"license": "MIT",
+			"dependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"ajv": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/body-parser": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+			"integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+			"license": "MIT",
+			"dependencies": {
+				"bytes": "^3.1.2",
+				"content-type": "^1.0.5",
+				"debug": "^4.4.3",
+				"http-errors": "^2.0.0",
+				"iconv-lite": "^0.7.0",
+				"on-finished": "^2.4.1",
+				"qs": "^6.14.1",
+				"raw-body": "^3.0.1",
+				"type-is": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/buffer-crc32": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+			"integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/byte-data": {
+			"version": "19.0.1",
+			"resolved": "https://registry.npmjs.org/byte-data/-/byte-data-19.0.1.tgz",
+			"integrity": "sha512-xRvkTvO28wr0+0rErSETHD8Cw+P444Az3/jkTezaMw5R+TTW8ZNXuvPZf9/ZhnSRRvlMnJsVhc+ecYvOMy/MQQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/bytes": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+			"integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/call-bind-apply-helpers": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/call-bound": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+			"integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"get-intrinsic": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/content-disposition": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+			"integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/content-type": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+			"integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/cookie": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/cookie-signature": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+			"integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.6.0"
+			}
+		},
+		"node_modules/cors": {
+			"version": "2.8.6",
+			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+			"integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+			"license": "MIT",
+			"dependencies": {
+				"object-assign": "^4",
+				"vary": "^1"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/cross-spawn": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+			"license": "MIT",
+			"dependencies": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/cross-spawn/node_modules/which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/depd": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+			"integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/dunder-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/ee-first": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+			"integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+			"license": "MIT"
+		},
+		"node_modules/encodeurl": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+			"integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/endianness": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/endianness/-/endianness-8.0.2.tgz",
+			"integrity": "sha512-IU+77+jJ7lpw2qZ3NUuqBZFy3GuioNgXUdsL1L9tooDNTaw0TgOnwNuc+8Ns+haDaTifK97QLzmOANJtI/rGvw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/es-define-property": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-errors": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-object-atoms": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+			"integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/escape-html": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+			"integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+			"license": "MIT"
+		},
+		"node_modules/etag": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+			"integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/eventsource": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+			"integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+			"license": "MIT",
+			"dependencies": {
+				"eventsource-parser": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/eventsource-parser": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+			"integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/express": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+			"integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"accepts": "^2.0.0",
+				"body-parser": "^2.2.1",
+				"content-disposition": "^1.0.0",
+				"content-type": "^1.0.5",
+				"cookie": "^0.7.1",
+				"cookie-signature": "^1.2.1",
+				"debug": "^4.4.0",
+				"depd": "^2.0.0",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"etag": "^1.8.1",
+				"finalhandler": "^2.1.0",
+				"fresh": "^2.0.0",
+				"http-errors": "^2.0.0",
+				"merge-descriptors": "^2.0.0",
+				"mime-types": "^3.0.0",
+				"on-finished": "^2.4.1",
+				"once": "^1.4.0",
+				"parseurl": "^1.3.3",
+				"proxy-addr": "^2.0.7",
+				"qs": "^6.14.0",
+				"range-parser": "^1.2.1",
+				"router": "^2.2.0",
+				"send": "^1.1.0",
+				"serve-static": "^2.2.0",
+				"statuses": "^2.0.1",
+				"type-is": "^2.0.1",
+				"vary": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/express-rate-limit": {
+			"version": "8.2.1",
+			"resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
+			"integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+			"license": "MIT",
+			"dependencies": {
+				"ip-address": "10.0.1"
+			},
+			"engines": {
+				"node": ">= 16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/express-rate-limit"
+			},
+			"peerDependencies": {
+				"express": ">= 4.11"
+			}
+		},
+		"node_modules/fast-deep-equal": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"license": "MIT"
+		},
+		"node_modules/fast-uri": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/finalhandler": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+			"integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.0",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"on-finished": "^2.4.1",
+				"parseurl": "^1.3.3",
+				"statuses": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/forwarded": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+			"integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/fresh": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+			"integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/function-bind": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-intrinsic": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"es-define-property": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.1.1",
+				"function-bind": "^1.1.2",
+				"get-proto": "^1.0.1",
+				"gopd": "^1.2.0",
+				"has-symbols": "^1.1.0",
+				"hasown": "^2.0.2",
+				"math-intrinsics": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+			"license": "MIT",
+			"dependencies": {
+				"dunder-proto": "^1.0.1",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/gopd": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-symbols": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/hasown": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+			"license": "MIT",
+			"dependencies": {
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/hono": {
+			"version": "4.12.2",
+			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.2.tgz",
+			"integrity": "sha512-gJnaDHXKDayjt8ue0n8Gs0A007yKXj4Xzb8+cNjZeYsSzzwKc0Lr+OZgYwVfB0pHfUs17EPoLvrOsEaJ9mj+Tg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=16.9.0"
+			}
+		},
+		"node_modules/http-errors": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+			"integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+			"license": "MIT",
+			"dependencies": {
+				"depd": "~2.0.0",
+				"inherits": "~2.0.4",
+				"setprototypeof": "~1.2.0",
+				"statuses": "~2.0.2",
+				"toidentifier": "~1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/iconv-lite": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+			"integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/ieee754-buffer": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ieee754-buffer/-/ieee754-buffer-2.0.0.tgz",
+			"integrity": "sha512-AXUAT0nMEi7h1Is8HXGXof3eejl/GabZFKSj8Ym6kVRUSwrAb52EkAXywiCQYSHGQMRn7lvfY7vhPMjVc+Kybg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"license": "ISC"
+		},
+		"node_modules/ip-address": {
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+			"integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/ipaddr.js": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
+		"node_modules/is-promise": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+			"integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+			"license": "MIT"
+		},
+		"node_modules/isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+			"license": "ISC"
+		},
+		"node_modules/jose": {
+			"version": "6.1.3",
+			"resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+			"integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/panva"
+			}
+		},
+		"node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"license": "MIT"
+		},
+		"node_modules/json-schema-typed": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+			"integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/math-intrinsics": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/media-typer": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+			"integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/merge-descriptors": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+			"integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/mime-db": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mime-types": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "^1.54.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"license": "MIT"
+		},
+		"node_modules/negotiator": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+			"integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/object-inspect": {
+			"version": "1.13.4",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+			"integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/on-finished": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+			"integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+			"license": "MIT",
+			"dependencies": {
+				"ee-first": "1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"license": "ISC",
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
+		"node_modules/parseurl": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/path-to-regexp": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+			"integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/pkce-challenge": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+			"integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/proxy-addr": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+			"integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+			"license": "MIT",
+			"dependencies": {
+				"forwarded": "0.2.0",
+				"ipaddr.js": "1.9.1"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
+		"node_modules/qs": {
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+			"integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"side-channel": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/range-parser": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+			"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/raw-body": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+			"integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+			"license": "MIT",
+			"dependencies": {
+				"bytes": "~3.1.2",
+				"http-errors": "~2.0.1",
+				"iconv-lite": "~0.7.0",
+				"unpipe": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
+		"node_modules/require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/riff-file": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/riff-file/-/riff-file-1.0.3.tgz",
+			"integrity": "sha512-Vv8wwGr0BCks7VMI3Lv0houZee4DaHFjjTT0LMhMJKio2YmLncLeIVpK63ydSverngNk8XQPU3fbeP3bWgSIig==",
+			"license": "MIT",
+			"dependencies": {
+				"byte-data": "^18.0.3"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/riff-file/node_modules/byte-data": {
+			"version": "18.1.1",
+			"resolved": "https://registry.npmjs.org/byte-data/-/byte-data-18.1.1.tgz",
+			"integrity": "sha512-Kv/B0r7adgnCcrs/y703sac2XFLdHW5kPfis1j8+Ij/hmEcWhBKf+1pNTv+vsNqXb207Uiyri8bpnogNxR/4Lg==",
+			"license": "MIT",
+			"dependencies": {
+				"endianness": "^8.0.2",
+				"ieee754-buffer": "^2.0.0",
+				"utf8-buffer": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/router": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+			"integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.0",
+				"depd": "^2.0.0",
+				"is-promise": "^4.0.0",
+				"parseurl": "^1.3.3",
+				"path-to-regexp": "^8.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"license": "MIT"
+		},
+		"node_modules/send": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+			"integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.3",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"etag": "^1.8.1",
+				"fresh": "^2.0.0",
+				"http-errors": "^2.0.1",
+				"mime-types": "^3.0.2",
+				"ms": "^2.1.3",
+				"on-finished": "^2.4.1",
+				"range-parser": "^1.2.1",
+				"statuses": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/serve-static": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+			"integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+			"license": "MIT",
+			"dependencies": {
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"parseurl": "^1.3.3",
+				"send": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/setprototypeof": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+			"integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+			"license": "ISC"
+		},
+		"node_modules/shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"license": "MIT",
+			"dependencies": {
+				"shebang-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/side-channel": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+			"integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"object-inspect": "^1.13.3",
+				"side-channel-list": "^1.0.0",
+				"side-channel-map": "^1.0.1",
+				"side-channel-weakmap": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-list": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+			"integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"object-inspect": "^1.13.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-map": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+			"integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.5",
+				"object-inspect": "^1.13.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-weakmap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+			"integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.5",
+				"object-inspect": "^1.13.3",
+				"side-channel-map": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/statuses": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+			"integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/toidentifier": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+			"integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.6"
+			}
+		},
+		"node_modules/type-is": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+			"integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+			"license": "MIT",
+			"dependencies": {
+				"content-type": "^1.0.5",
+				"media-typer": "^1.1.0",
+				"mime-types": "^3.0.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/typescript": {
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
+		"node_modules/undici-types": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/unpipe": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+			"integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/utf8-buffer": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/utf8-buffer/-/utf8-buffer-1.0.0.tgz",
+			"integrity": "sha512-ueuhzvWnp5JU5CiGSY4WdKbiN/PO2AZ/lpeLiz2l38qwdLy/cW40XobgyuIWucNyum0B33bVB0owjFCeGBSLqg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/vary": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+			"integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/which": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/which/-/which-3.0.1.tgz",
+			"integrity": "sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==",
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/which.js"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+			"license": "ISC"
+		},
+		"node_modules/yazl": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/yazl/-/yazl-3.3.1.tgz",
+			"integrity": "sha512-BbETDVWG+VcMUle37k5Fqp//7SDOK2/1+T7X8TD96M3D9G8jK5VLUdQVdVjGi8im7FGkazX7kk5hkU8X4L5Bng==",
+			"license": "MIT",
+			"dependencies": {
+				"buffer-crc32": "^1.0.0"
+			}
+		},
+		"node_modules/zod": {
+			"version": "3.25.76",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+			"license": "MIT",
+			"peer": true,
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/zod-to-json-schema": {
+			"version": "3.25.1",
+			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+			"integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+			"license": "ISC",
+			"peerDependencies": {
+				"zod": "^3.25 || ^4"
+			}
+		}
+	}
+}

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,0 +1,38 @@
+{
+	"name": "@vert-sh/mcp-server",
+	"version": "0.1.0",
+	"type": "module",
+	"bin": "./dist/index.js",
+	"files": [
+		"dist/"
+	],
+	"license": "AGPL-3.0-only",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/VERT-sh/VERT",
+		"directory": "mcp"
+	},
+	"scripts": {
+		"build": "tsc",
+		"start": "node dist/index.js",
+		"prepublishOnly": "tsc"
+	},
+	"dependencies": {
+		"@imagemagick/magick-wasm": "0.0.38",
+		"@modelcontextprotocol/sdk": "1.27.0",
+		"byte-data": "19.0.1",
+		"riff-file": "1.0.3",
+		"which": "^3.0.0",
+		"yazl": "3.3.1",
+		"zod": "^3.25.0"
+	},
+	"devDependencies": {
+		"@types/node": "^22",
+		"@types/which": "^3",
+		"@types/yazl": "^2",
+		"typescript": "^5.9.3"
+	},
+	"engines": {
+		"node": ">=18.0.0"
+	}
+}

--- a/mcp/src/converters/ffmpeg.ts
+++ b/mcp/src/converters/ffmpeg.ts
@@ -1,0 +1,355 @@
+import { execFile } from "node:child_process";
+import { stat } from "node:fs/promises";
+import path from "node:path";
+import which from "which";
+import { FormatInfo } from "./types.js";
+import type { ConvertOptions, ConvertResult, NodeConverter } from "./types.js";
+
+/** Conversion timeout in milliseconds. */
+const TIMEOUT_MS = 120_000;
+
+/** Maximum number of concurrent ffmpeg processes. */
+const MAX_CONCURRENT = 3;
+
+// ── Audio format definitions (from VERT ffmpeg.svelte.ts lines 43-74) ──
+
+const AUDIO_FORMATS: FormatInfo[] = [
+	new FormatInfo("mp3"),
+	new FormatInfo("wav"),
+	new FormatInfo("flac"),
+	new FormatInfo("ogg"),
+	new FormatInfo("mogg", true, false),       // from only
+	new FormatInfo("oga"),
+	new FormatInfo("opus"),
+	new FormatInfo("aac"),
+	new FormatInfo("alac"),                     // output extension becomes .m4a
+	new FormatInfo("m4a"),
+	new FormatInfo("caf", true, false),         // from only
+	new FormatInfo("wma"),
+	new FormatInfo("amr"),
+	new FormatInfo("ac3"),
+	new FormatInfo("aiff"),
+	new FormatInfo("aifc"),
+	new FormatInfo("aif"),
+	new FormatInfo("mp1", true, false),         // from only
+	new FormatInfo("mp2"),
+	new FormatInfo("mpc", true, false),         // from only
+	new FormatInfo("dsd", true, false),         // from only
+	new FormatInfo("dsf", true, false),         // from only
+	new FormatInfo("dff", true, false),         // from only
+	new FormatInfo("mqa", true, false),         // from only
+	new FormatInfo("au"),
+	new FormatInfo("m4b"),
+	new FormatInfo("voc"),
+	new FormatInfo("weba"),
+];
+
+// ── Video format definitions (input only for audio extraction) ──
+
+const VIDEO_FORMATS: FormatInfo[] = [
+	new FormatInfo("mkv", true, false, false),
+	new FormatInfo("mp4", true, false, false),
+	new FormatInfo("avi", true, false, false),
+	new FormatInfo("mov", true, false, false),
+	new FormatInfo("webm", true, false, false),
+	new FormatInfo("ts", true, false, false),
+	new FormatInfo("mts", true, false, false),
+	new FormatInfo("m2ts", true, false, false),
+	new FormatInfo("wmv", true, false, false),
+	new FormatInfo("mpg", true, false, false),
+	new FormatInfo("mpeg", true, false, false),
+	new FormatInfo("flv", true, false, false),
+	new FormatInfo("f4v", true, false, false),
+	new FormatInfo("vob", true, false, false),
+	new FormatInfo("m4v", true, false, false),
+	new FormatInfo("3gp", true, false, false),
+	new FormatInfo("3g2", true, false, false),
+	new FormatInfo("mxf", true, false, false),
+	new FormatInfo("ogv", true, false, false),
+	new FormatInfo("rm", true, false, false),
+	new FormatInfo("rmvb", true, false, false),
+	new FormatInfo("divx", true, false, false),
+];
+
+/** Set of video extensions (undotted, lowercase) for detecting video input. */
+const VIDEO_EXTENSIONS = new Set(
+	VIDEO_FORMATS.map((f) => f.name.slice(1).toLowerCase()),
+);
+
+// ── Codec mappings (from VERT ffmpeg.svelte.ts lines 636-699 + additions) ──
+
+/**
+ * Get the FFmpeg codec string for a given output format extension.
+ * Adapted from VERT's getCodecs() with additions for missing codecs.
+ */
+function getCodec(ext: string): string {
+	switch (ext) {
+		case "mp3":
+			return "libmp3lame";
+		case "wav":
+			return "pcm_s16le";
+		case "flac":
+			return "flac";
+		case "ogg":
+		case "oga":
+			return "libvorbis";
+		case "opus":
+			return "libopus";
+		case "aac":
+			return "aac";
+		case "alac":
+			return "alac";
+		case "m4a":
+			return "aac";
+		case "m4b":
+			return "aac";
+		case "wma":
+			return "wmav2";
+		case "amr":
+			return "libopencore_amrnb";
+		case "ac3":
+			return "ac3";
+		case "aiff":
+		case "aifc":
+		case "aif":
+			return "pcm_s16be";
+		case "mp2":
+			return "mp2";
+		case "au":
+			return "pcm_mulaw";
+		case "voc":
+			return "pcm_u8";
+		case "weba":
+			return "libopus";
+		case "caf":
+			return "pcm_s16le";
+		default:
+			return "copy";
+	}
+}
+
+/**
+ * Check if the given extension is a video format we recognize as input.
+ */
+function isVideoInput(ext: string): boolean {
+	return VIDEO_EXTENSIONS.has(ext.toLowerCase());
+}
+
+// ── Concurrency limiter ──
+
+let activeProcesses = 0;
+const waitQueue: Array<() => void> = [];
+
+function acquireSlot(): Promise<void> {
+	if (activeProcesses < MAX_CONCURRENT) {
+		activeProcesses++;
+		return Promise.resolve();
+	}
+	return new Promise<void>((resolve) => {
+		waitQueue.push(() => {
+			activeProcesses++;
+			resolve();
+		});
+	});
+}
+
+function releaseSlot(): void {
+	activeProcesses--;
+	const next = waitQueue.shift();
+	if (next) {
+		next();
+	}
+}
+
+// ── Helpers ──
+
+/**
+ * Run ffmpeg with the given arguments via execFile (no shell).
+ * Returns a promise that resolves on success or rejects on failure.
+ */
+function runFFmpeg(ffmpegPath: string, args: string[]): Promise<{ stdout: string; stderr: string }> {
+	return new Promise((resolve, reject) => {
+		execFile(
+			ffmpegPath,
+			args,
+			{
+				timeout: TIMEOUT_MS,
+				maxBuffer: 10 * 1024 * 1024,
+				windowsHide: true,
+			},
+			(error, stdout, stderr) => {
+				if (error) {
+					reject(new Error(
+						`ffmpeg failed: ${error.message}\n${stderr}`,
+					));
+				} else {
+					resolve({ stdout, stderr });
+				}
+			},
+		);
+	});
+}
+
+/**
+ * Build the FFmpeg conversion command arguments.
+ * Adapted from VERT's buildConversionCommand() (ffmpeg.svelte.ts lines 315-527).
+ */
+function buildConversionArgs(options: ConvertOptions, inputExt: string): string[] {
+	const {
+		inputPath,
+		outputPath,
+		outputFormat,
+		audioBitrate,
+		sampleRate,
+		keepMetadata,
+	} = options;
+
+	// Determine the actual output format and codec
+	let actualOutputFormat = outputFormat.toLowerCase();
+	let actualOutputPath = outputPath;
+
+	// ALAC: output_format="alac" -> actual file ext .m4a, codec alac
+	if (actualOutputFormat === "alac") {
+		// The output path should already have .m4a extension (handled by caller),
+		// but the codec is "alac"
+		actualOutputFormat = "alac";
+	}
+
+	const codec = getCodec(actualOutputFormat);
+	const isVideoSource = isVideoInput(inputExt);
+
+	const args: string[] = [];
+
+	// Security: restrict protocols to prevent SSRF
+	args.push("-protocol_whitelist", "file,pipe");
+
+	// Overwrite output without asking (we handle uniqueness ourselves)
+	args.push("-y");
+
+	// Input file
+	// -i takes its argument directly; no -- between flag and value.
+	args.push("-i", inputPath);
+
+	// If extracting audio from video, map only the first audio stream
+	if (isVideoSource) {
+		args.push("-map", "0:a:0");
+	}
+
+	// Audio codec
+	if (codec !== "copy") {
+		args.push("-c:a", codec);
+	}
+
+	// Metadata handling
+	if (keepMetadata === false) {
+		args.push("-map_metadata", "-1");
+		args.push("-map_chapters", "-1");
+		if (!isVideoSource) {
+			args.push("-map", "a");
+		}
+	}
+
+	// Audio bitrate
+	if (audioBitrate) {
+		args.push("-b:a", audioBitrate);
+	}
+
+	// Sample rate handling
+	if (sampleRate) {
+		// Opus 44100 -> 48000 auto-adjustment
+		if ((actualOutputFormat === "opus" || actualOutputFormat === "weba") && sampleRate === 44100) {
+			args.push("-ar", "48000");
+		} else {
+			args.push("-ar", String(sampleRate));
+		}
+	} else {
+		// If no sample rate specified and output is opus, default to 48000
+		// (Opus doesn't support 44100Hz)
+		if (actualOutputFormat === "opus" || actualOutputFormat === "weba") {
+			args.push("-ar", "48000");
+		}
+	}
+
+	// End of options separator, then output file path
+	// -- prevents output paths starting with "-" from being interpreted as flags
+	args.push("--", actualOutputPath);
+
+	return args;
+}
+
+// ── FFmpeg Node Converter ──
+
+/**
+ * FFmpeg-based audio converter using the system ffmpeg binary.
+ * Gracefully unavailable if ffmpeg is not installed.
+ */
+export class FFmpegNodeConverter implements NodeConverter {
+	readonly name = "ffmpeg";
+	readonly supportedFormats: FormatInfo[] = [...AUDIO_FORMATS, ...VIDEO_FORMATS];
+
+	private ffmpegPath: string | null = null;
+	private available: boolean | null = null;
+
+	/**
+	 * Check if ffmpeg is available on the system.
+	 * Caches the result after the first check.
+	 */
+	async isAvailable(): Promise<boolean> {
+		if (this.available !== null) {
+			return this.available;
+		}
+
+		try {
+			this.ffmpegPath = await which("ffmpeg");
+			this.available = true;
+		} catch {
+			this.ffmpegPath = null;
+			this.available = false;
+		}
+
+		return this.available;
+	}
+
+	/**
+	 * Convert an audio file using system ffmpeg.
+	 * Supports audio-to-audio conversion and video-to-audio extraction.
+	 */
+	async convert(options: ConvertOptions): Promise<ConvertResult> {
+		if (!(await this.isAvailable()) || !this.ffmpegPath) {
+			throw new Error("ffmpeg is not installed on this system");
+		}
+
+		const inputExt = path.extname(options.inputPath).slice(1).toLowerCase();
+
+		// Determine actual output path (ALAC uses .m4a extension)
+		let actualOutputPath = options.outputPath;
+		if (options.outputFormat.toLowerCase() === "alac") {
+			const dir = path.dirname(options.outputPath);
+			const base = path.basename(options.outputPath, path.extname(options.outputPath));
+			actualOutputPath = path.join(dir, `${base}.m4a`);
+		}
+
+		const effectiveOptions: ConvertOptions = {
+			...options,
+			outputPath: actualOutputPath,
+		};
+
+		const args = buildConversionArgs(effectiveOptions, inputExt);
+
+		await acquireSlot();
+		try {
+			await runFFmpeg(this.ffmpegPath, args);
+		} finally {
+			releaseSlot();
+		}
+
+		// Verify output exists and get size
+		const stats = await stat(actualOutputPath);
+
+		return {
+			outputPath: actualOutputPath,
+			format: options.outputFormat.toLowerCase(),
+			sizeBytes: stats.size,
+		};
+	}
+}

--- a/mcp/src/converters/magick.ts
+++ b/mcp/src/converters/magick.ts
@@ -1,0 +1,620 @@
+import { createRequire } from "node:module";
+import { readFileSync, writeFileSync, statSync } from "node:fs";
+import { basename, extname } from "node:path";
+import {
+	initializeImageMagick,
+	ImageMagick,
+	MagickFormat,
+	MagickReadSettings,
+} from "@imagemagick/magick-wasm";
+import yazl from "yazl";
+import { parseAni } from "../util/parse-ani.js";
+import { FormatInfo, type ConvertOptions, type ConvertResult, type NodeConverter } from "./types.js";
+
+/** Maximum number of frames to extract from ICO/ANI files. */
+const MAX_FRAMES = 256;
+
+/** Conversion timeout in milliseconds. */
+const CONVERSION_TIMEOUT_MS = 120_000;
+
+// ---------------------------------------------------------------------------
+// Format lists
+// ---------------------------------------------------------------------------
+
+// Blocked formats that lack WASM delegates or are unsafe:
+// svg, nef, cr2, arw, dng, rw2, raf, orf, pef, mos, raw, dcr, crw, cr3, 3fr,
+// erf, mrw, mef, nrw, srw, sr2, srf, eps, icns, xcf
+// ps, ps1, svgz, epdf, epi, eps2, eps3, epsf, epsi, ept, ept2, ept3
+
+/** Manually tested image formats from VERT (magick.svelte.ts lines 19-78), blocked formats removed. */
+const MANUAL_FORMATS: FormatInfo[] = [
+	new FormatInfo("png", true, true),
+	new FormatInfo("jpeg", true, true),
+	new FormatInfo("jpg", true, true),
+	new FormatInfo("webp", true, true),
+	new FormatInfo("gif", true, true),
+	// svg blocked (no WASM delegate)
+	new FormatInfo("jxl", true, true),
+	new FormatInfo("avif", true, true),
+	new FormatInfo("heic", true, false),
+	new FormatInfo("heif", true, false),
+	new FormatInfo("ico", true, true),
+	new FormatInfo("bmp", true, true),
+	new FormatInfo("cur", true, true),
+	new FormatInfo("ani", true, false),
+	// icns blocked (needs vert-wasm)
+	// nef blocked (needs libraw)
+	// cr2 blocked (needs libraw)
+	new FormatInfo("hdr", true, true),
+	new FormatInfo("jpe", true, true),
+	new FormatInfo("mat", true, true),
+	new FormatInfo("pbm", true, true),
+	new FormatInfo("pfm", true, true),
+	new FormatInfo("pgm", true, true),
+	new FormatInfo("pnm", true, true),
+	new FormatInfo("ppm", true, true),
+	new FormatInfo("tiff", true, true),
+	new FormatInfo("jfif", true, true),
+	// eps blocked (needs Ghostscript)
+	new FormatInfo("psd", true, true),
+	new FormatInfo("svg", false, true),
+	new FormatInfo("svgz", false, true),
+	// arw blocked (needs libraw)
+	new FormatInfo("tif", true, true),
+	// dng blocked (needs libraw)
+	// xcf blocked
+	// rw2 blocked (needs libraw)
+	// raf blocked (needs libraw)
+	// orf blocked (needs libraw)
+	// pef blocked (needs libraw)
+	// mos blocked (needs libraw)
+	// raw blocked (needs libraw)
+	// dcr blocked (needs libraw)
+	// crw blocked (needs libraw)
+	// cr3 blocked (needs libraw)
+	// 3fr blocked (needs libraw)
+	// erf blocked (needs libraw)
+	// mrw blocked (needs libraw)
+	// mef blocked (needs libraw)
+	// nrw blocked (needs libraw)
+	// srw blocked (needs libraw)
+	// sr2 blocked (needs libraw)
+	// srf blocked (needs libraw)
+];
+
+/** Automated formats from VERT (magick-automated.ts), blocked formats removed. */
+const AUTOMATED_FORMATS: FormatInfo[] = [
+	new FormatInfo("a", false, true),
+	new FormatInfo("aai", true, true),
+	new FormatInfo("ai", false, true),
+	new FormatInfo("art", false, true),
+	new FormatInfo("avs", true, true),
+	new FormatInfo("b", false, true),
+	new FormatInfo("bgr", false, true),
+	new FormatInfo("bgra", false, true),
+	new FormatInfo("bgro", false, true),
+	new FormatInfo("bmp2", true, true),
+	new FormatInfo("bmp3", true, true),
+	new FormatInfo("brf", false, true),
+	new FormatInfo("cal", false, true),
+	new FormatInfo("cals", false, true),
+	new FormatInfo("cin", true, true),
+	new FormatInfo("cip", false, true),
+	new FormatInfo("cmyk", false, true),
+	new FormatInfo("cmyka", false, true),
+	new FormatInfo("dcx", true, true),
+	new FormatInfo("dds", true, true),
+	new FormatInfo("dpx", true, true),
+	new FormatInfo("dxt1", true, true),
+	new FormatInfo("dxt5", true, true),
+	// epdf blocked
+	// epi blocked
+	// eps2 blocked
+	// eps3 blocked
+	// epsf blocked
+	// epsi blocked
+	// ept blocked
+	// ept2 blocked
+	// ept3 blocked
+	new FormatInfo("exr", true, true),
+	new FormatInfo("farbfeld", true, true),
+	new FormatInfo("fax", true, true),
+	new FormatInfo("ff", true, true),
+	new FormatInfo("fit", true, true),
+	new FormatInfo("fits", true, true),
+	new FormatInfo("fl32", true, true),
+	new FormatInfo("fts", true, true),
+	new FormatInfo("ftxt", false, true),
+	new FormatInfo("g", false, true),
+	new FormatInfo("g3", true, true),
+	new FormatInfo("g4", false, true),
+	new FormatInfo("gif87", true, true),
+	new FormatInfo("gray", false, true),
+	new FormatInfo("graya", false, true),
+	new FormatInfo("group4", false, true),
+	new FormatInfo("hrz", true, true),
+	new FormatInfo("icb", true, true),
+	new FormatInfo("icon", true, true),
+	new FormatInfo("info", false, true),
+	new FormatInfo("ipl", true, true),
+	new FormatInfo("isobrl", false, true),
+	new FormatInfo("isobrl6", false, true),
+	new FormatInfo("j2c", true, true),
+	new FormatInfo("j2k", true, true),
+	new FormatInfo("jng", true, true),
+	new FormatInfo("jp2", true, true),
+	new FormatInfo("jpc", true, true),
+	new FormatInfo("jpm", true, true),
+	new FormatInfo("jps", true, true),
+	new FormatInfo("map", false, true),
+	new FormatInfo("miff", true, true),
+	new FormatInfo("mng", true, true),
+	new FormatInfo("mono", false, true),
+	new FormatInfo("mtv", true, true),
+	new FormatInfo("o", false, true),
+	new FormatInfo("otb", true, true),
+	new FormatInfo("pal", false, true),
+	new FormatInfo("palm", true, true),
+	new FormatInfo("pam", true, true),
+	new FormatInfo("pcd", true, true),
+	new FormatInfo("pcds", true, true),
+	new FormatInfo("pcl", false, true),
+	new FormatInfo("pct", true, true),
+	new FormatInfo("pcx", true, true),
+	new FormatInfo("pdb", true, true),
+	new FormatInfo("pgx", true, true),
+	new FormatInfo("phm", true, true),
+	new FormatInfo("picon", true, true),
+	new FormatInfo("pict", true, true),
+	new FormatInfo("pjpeg", true, true),
+	new FormatInfo("png00", true, true),
+	new FormatInfo("png24", true, true),
+	new FormatInfo("png32", true, true),
+	new FormatInfo("png48", true, true),
+	new FormatInfo("png64", true, true),
+	new FormatInfo("png8", true, true),
+	// ps blocked
+	// ps1 blocked
+	new FormatInfo("ps2", false, true),
+	new FormatInfo("ps3", false, true),
+	new FormatInfo("psb", true, true),
+	new FormatInfo("ptif", true, true),
+	new FormatInfo("qoi", true, true),
+	new FormatInfo("r", false, true),
+	new FormatInfo("ras", true, true),
+	new FormatInfo("rgb", false, true),
+	new FormatInfo("rgba", false, true),
+	new FormatInfo("rgbo", false, true),
+	new FormatInfo("rgf", true, true),
+	new FormatInfo("sgi", true, true),
+	new FormatInfo("six", true, true),
+	new FormatInfo("sixel", true, true),
+	new FormatInfo("sparse-color", false, true),
+	new FormatInfo("strimg", false, true),
+	new FormatInfo("sun", true, true),
+	// svgz blocked
+	new FormatInfo("tga", true, true),
+	new FormatInfo("tiff64", true, true),
+	new FormatInfo("ubrl", false, true),
+	new FormatInfo("ubrl6", false, true),
+	new FormatInfo("uil", false, true),
+	new FormatInfo("uyvy", false, true),
+	new FormatInfo("vda", true, true),
+	new FormatInfo("vicar", true, true),
+	new FormatInfo("viff", true, true),
+	new FormatInfo("vips", true, true),
+	new FormatInfo("vst", true, true),
+	new FormatInfo("wbmp", true, true),
+	new FormatInfo("wpg", true, true),
+	new FormatInfo("xbm", true, true),
+	new FormatInfo("xpm", true, true),
+	new FormatInfo("xv", true, true),
+	new FormatInfo("ycbcr", false, true),
+	new FormatInfo("ycbcra", false, true),
+	new FormatInfo("yuv", false, true),
+];
+
+// ---------------------------------------------------------------------------
+// Format normalization helpers
+// ---------------------------------------------------------------------------
+
+/** Normalize input extension: .jfif->.jpeg, .fit->.fits (bidirectional). */
+function normalizeInputExt(ext: string): string {
+	const lower = ext.toLowerCase();
+	if (lower === ".jfif") return ".jpeg";
+	if (lower === ".fit") return ".fits";
+	return lower;
+}
+
+/** Normalize output extension: .jfif->.jpeg, .fit->.fits (bidirectional). */
+function normalizeOutputExt(ext: string): string {
+	const lower = ext.toLowerCase();
+	if (lower === ".jfif") return ".jpeg";
+	if (lower === ".fit") return ".fits";
+	return lower;
+}
+
+/** Convert an extension (without dot) to a MagickFormat enum value. */
+function extToMagickFormat(ext: string): MagickFormat {
+	return ext.toUpperCase() as unknown as MagickFormat;
+}
+
+// ---------------------------------------------------------------------------
+// Serialization queue
+// ---------------------------------------------------------------------------
+
+/** Simple serialization queue — ensures one conversion at a time for the single WASM instance. */
+class SerialQueue {
+	private queue: Array<{ run: () => Promise<void>; }> = [];
+	private running = false;
+
+	enqueue<T>(fn: () => Promise<T>): Promise<T> {
+		return new Promise<T>((resolve, reject) => {
+			this.queue.push({
+				run: async () => {
+					try {
+						resolve(await fn());
+					} catch (err) {
+						reject(err);
+					}
+				},
+			});
+			this.drain();
+		});
+	}
+
+	private async drain(): Promise<void> {
+		if (this.running) return;
+		this.running = true;
+		while (this.queue.length > 0) {
+			const item = this.queue.shift()!;
+			await item.run();
+		}
+		this.running = false;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ZIP helper using yazl
+// ---------------------------------------------------------------------------
+
+/** Create a ZIP buffer from an array of named buffers. */
+function createZip(entries: Array<{ name: string; data: Buffer }>): Promise<Buffer> {
+	return new Promise<Buffer>((resolve, reject) => {
+		const zipFile = new yazl.ZipFile();
+		for (const entry of entries) {
+			zipFile.addBuffer(entry.data, entry.name);
+		}
+		zipFile.end();
+
+		const chunks: Buffer[] = [];
+		zipFile.outputStream.on("data", (chunk: Buffer) => {
+			chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+		});
+		zipFile.outputStream.on("end", () => {
+			resolve(Buffer.concat(chunks));
+		});
+		zipFile.outputStream.on("error", (err: Error) => {
+			reject(err);
+		});
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Timeout helper
+// ---------------------------------------------------------------------------
+
+function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+	return new Promise<T>((resolve, reject) => {
+		const timer = setTimeout(() => {
+			reject(new Error(`Conversion timed out after ${ms / 1000} seconds: ${label}`));
+		}, ms);
+		promise.then(
+			(val) => { clearTimeout(timer); resolve(val); },
+			(err) => { clearTimeout(timer); reject(err); },
+		);
+	});
+}
+
+// ---------------------------------------------------------------------------
+// MagickNodeConverter
+// ---------------------------------------------------------------------------
+
+/**
+ * ImageMagick WASM converter for Node.js.
+ * Uses @imagemagick/magick-wasm with lazy initialization, serialized queue,
+ * and callback-based auto-disposal.
+ */
+export class MagickNodeConverter implements NodeConverter {
+	readonly name = "imagemagick";
+	readonly supportedFormats: FormatInfo[] = [...MANUAL_FORMATS, ...AUTOMATED_FORMATS];
+
+	private initialized = false;
+	private initPromise: Promise<void> | null = null;
+	private readonly queue = new SerialQueue();
+
+	/** Lazy-initialize the WASM module on first call. */
+	private async ensureInitialized(): Promise<void> {
+		if (this.initialized) return;
+		if (this.initPromise) {
+			await this.initPromise;
+			return;
+		}
+		this.initPromise = (async () => {
+			const require = createRequire(import.meta.url);
+			const wasmPath = require.resolve("@imagemagick/magick-wasm/magick.wasm");
+			const wasmBytes = readFileSync(wasmPath);
+			await initializeImageMagick(wasmBytes);
+			this.initialized = true;
+		})();
+		await this.initPromise;
+	}
+
+	/** ImageMagick WASM is always available (bundled). */
+	async isAvailable(): Promise<boolean> {
+		return true;
+	}
+
+	/** Convert an image file. */
+	async convert(options: ConvertOptions): Promise<ConvertResult> {
+		await this.ensureInitialized();
+
+		return withTimeout(
+			this.queue.enqueue(() => this.doConvert(options)),
+			CONVERSION_TIMEOUT_MS,
+			`${basename(options.inputPath)} -> ${options.outputFormat}`,
+		);
+	}
+
+	/** Internal conversion dispatched inside the serialized queue. */
+	private async doConvert(options: ConvertOptions): Promise<ConvertResult> {
+		const { inputPath, outputPath, quality, keepMetadata = true } = options;
+		const inputBytes = new Uint8Array(readFileSync(inputPath));
+
+		const rawInputExt = extname(inputPath).toLowerCase();
+		const from = normalizeInputExt(rawInputExt);
+
+		let outputExt = options.outputFormat.startsWith(".")
+			? options.outputFormat.toLowerCase()
+			: `.${options.outputFormat.toLowerCase()}`;
+		outputExt = normalizeOutputExt(outputExt);
+
+		// -----------------------------------------------------------------
+		// ICO input: extract individual frames → ZIP
+		// -----------------------------------------------------------------
+		if (from === ".ico") {
+			return this.convertIco(inputBytes, outputExt, outputPath, keepMetadata, quality);
+		}
+
+		// -----------------------------------------------------------------
+		// ANI input: parse frames → convert each → ZIP
+		// -----------------------------------------------------------------
+		if (from === ".ani") {
+			return this.convertAni(inputBytes, outputExt, outputPath, keepMetadata, quality);
+		}
+
+		// -----------------------------------------------------------------
+		// Animated GIF/WebP input → GIF/WebP output: use readCollection
+		// -----------------------------------------------------------------
+		if (
+			(from === ".gif" || from === ".webp") &&
+			(outputExt === ".gif" || outputExt === ".webp")
+		) {
+			return this.convertAnimated(inputBytes, from, outputExt, outputPath, keepMetadata, quality);
+		}
+
+		// -----------------------------------------------------------------
+		// Standard single-image conversion
+		// -----------------------------------------------------------------
+		const outputFmt = extToMagickFormat(outputExt.slice(1));
+		const inputFmt = extToMagickFormat(from.slice(1));
+
+		const result = ImageMagick.read(inputBytes, new MagickReadSettings({ format: inputFmt }), (img) => {
+			// ICO output: clamp to 256x256 max
+			if (outputExt === ".ico") {
+				this.clampForIco(img);
+			}
+
+			if (quality !== undefined) {
+				img.quality = quality;
+			}
+			if (!keepMetadata) {
+				img.strip();
+			}
+
+			let outputBuffer: Buffer = Buffer.alloc(0);
+			img.write(outputFmt, (data) => {
+				outputBuffer = Buffer.from(data);
+			});
+			return outputBuffer;
+		});
+
+		writeFileSync(outputPath, result);
+
+		const stat = statSync(outputPath);
+		return {
+			outputPath,
+			format: outputExt.slice(1),
+			sizeBytes: stat.size,
+		};
+	}
+
+	/** Convert ICO: read individual frames, convert each, ZIP output. */
+	private async convertIco(
+		inputBytes: Uint8Array,
+		outputExt: string,
+		outputPath: string,
+		keepMetadata: boolean,
+		quality?: number,
+	): Promise<ConvertResult> {
+		const outputFmt = extToMagickFormat(outputExt.slice(1));
+		const entries: Array<{ name: string; data: Buffer }> = [];
+
+		for (let i = 0; i < MAX_FRAMES; i++) {
+			try {
+				const frameBuffer = ImageMagick.read(
+					inputBytes,
+					new MagickReadSettings({
+						format: MagickFormat.Ico,
+						frameIndex: i,
+					}),
+					(img) => {
+						if (outputExt === ".ico") {
+							this.clampForIco(img);
+						}
+						if (quality !== undefined) {
+							img.quality = quality;
+						}
+						if (!keepMetadata) {
+							img.strip();
+						}
+
+						let buf: Buffer = Buffer.alloc(0);
+						img.write(outputFmt, (data) => {
+							buf = Buffer.from(data);
+						});
+						return buf;
+					},
+				);
+				entries.push({
+					name: `image${i}${outputExt}`,
+					data: frameBuffer,
+				});
+			} catch {
+				// No more frames
+				break;
+			}
+		}
+
+		if (entries.length === 0) {
+			throw new Error("Failed to read ICO — no images found");
+		}
+
+		const zipPath = outputPath.replace(/\.[^.]+$/, ".zip");
+		const zipBuffer = await createZip(entries);
+		writeFileSync(zipPath, zipBuffer);
+
+		const stat = statSync(zipPath);
+		return {
+			outputPath: zipPath,
+			format: "zip",
+			sizeBytes: stat.size,
+		};
+	}
+
+	/** Convert ANI: parse with parseAni(), convert each frame, ZIP output. */
+	private async convertAni(
+		inputBytes: Uint8Array,
+		outputExt: string,
+		outputPath: string,
+		keepMetadata: boolean,
+		quality?: number,
+	): Promise<ConvertResult> {
+		let parsedAni;
+		try {
+			parsedAni = parseAni(inputBytes);
+		} catch (err) {
+			throw new Error(`Failed to parse ANI file: ${(err as Error).message}`);
+		}
+
+		const outputFmt = extToMagickFormat(outputExt.slice(1));
+		const frames = parsedAni.images.slice(0, MAX_FRAMES);
+
+		if (frames.length === 0) {
+			throw new Error("Failed to parse ANI — no frames found");
+		}
+
+		const entries: Array<{ name: string; data: Buffer }> = [];
+
+		for (let i = 0; i < frames.length; i++) {
+			const frameData = frames[i];
+			const frameBuffer = ImageMagick.read(
+				frameData,
+				new MagickReadSettings({ format: MagickFormat.Ico }),
+				(img) => {
+					if (outputExt === ".ico") {
+						this.clampForIco(img);
+					}
+					if (quality !== undefined) {
+						img.quality = quality;
+					}
+					if (!keepMetadata) {
+						img.strip();
+					}
+
+					let buf: Buffer = Buffer.alloc(0);
+					img.write(outputFmt, (data) => {
+						buf = Buffer.from(data);
+					});
+					return buf;
+				},
+			);
+			entries.push({
+				name: `image${i}${outputExt}`,
+				data: frameBuffer,
+			});
+		}
+
+		const zipPath = outputPath.replace(/\.[^.]+$/, ".zip");
+		const zipBuffer = await createZip(entries);
+		writeFileSync(zipPath, zipBuffer);
+
+		const stat = statSync(zipPath);
+		return {
+			outputPath: zipPath,
+			format: "zip",
+			sizeBytes: stat.size,
+		};
+	}
+
+	/** Convert animated GIF/WebP → GIF/WebP using readCollection. */
+	private async convertAnimated(
+		inputBytes: Uint8Array,
+		_from: string,
+		outputExt: string,
+		outputPath: string,
+		keepMetadata: boolean,
+		quality?: number,
+	): Promise<ConvertResult> {
+		const outputFmt = outputExt === ".gif" ? MagickFormat.Gif : MagickFormat.WebP;
+
+		const result = ImageMagick.readCollection(inputBytes, (imgs) => {
+			for (const img of imgs) {
+				if (quality !== undefined) {
+					img.quality = quality;
+				}
+				if (!keepMetadata) {
+					img.strip();
+				}
+			}
+
+			let outputBuffer: Buffer = Buffer.alloc(0);
+			imgs.write(outputFmt, (data) => {
+				outputBuffer = Buffer.from(data);
+			});
+			return outputBuffer;
+		});
+
+		writeFileSync(outputPath, result);
+
+		const stat = statSync(outputPath);
+		return {
+			outputPath,
+			format: outputExt.slice(1),
+			sizeBytes: stat.size,
+		};
+	}
+
+	/** Clamp image dimensions to 256x256 for ICO output. */
+	private clampForIco(img: { width: number; height: number; resize: (w: number, h: number) => void }): void {
+		const max = 256;
+		const w = img.width;
+		const h = img.height;
+		if (w > max || h > max) {
+			const scale = max / Math.max(w, h);
+			const newW = Math.max(1, Math.round(w * scale));
+			const newH = Math.max(1, Math.round(h * scale));
+			img.resize(newW, newH);
+		}
+	}
+}

--- a/mcp/src/converters/pandoc.ts
+++ b/mcp/src/converters/pandoc.ts
@@ -1,0 +1,194 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { stat, rm, mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import which from "which";
+import { FormatInfo, type ConvertOptions, type ConvertResult, type NodeConverter } from "./types.js";
+
+const execFileAsync = promisify(execFile);
+
+/** Conversion timeout in milliseconds. */
+const TIMEOUT_MS = 120_000;
+
+/** Max concurrent pandoc processes. */
+const MAX_CONCURRENT = 3;
+
+/**
+ * Map file extension (without dot) to pandoc reader name.
+ */
+function formatToReader(ext: string): string {
+	switch (ext) {
+		case "md":
+		case "markdown":
+			return "markdown";
+		case "docx":
+			return "docx";
+		case "csv":
+			return "csv";
+		case "tsv":
+			return "tsv";
+		case "docbook":
+			return "docbook";
+		case "epub":
+			return "epub";
+		case "html":
+			return "html";
+		case "json":
+			return "json";
+		case "odt":
+			return "odt";
+		case "rtf":
+			return "rtf";
+		case "rst":
+			return "rst";
+		default:
+			throw new Error(`Unsupported pandoc input format: ${ext}`);
+	}
+}
+
+/**
+ * Map file extension (without dot) to pandoc writer name.
+ * Separate from reader because some writer names differ.
+ */
+function formatToWriter(ext: string): string {
+	switch (ext) {
+		case "md":
+		case "markdown":
+			return "markdown";
+		case "docx":
+			return "docx";
+		case "csv":
+			return "csv";
+		case "tsv":
+			return "tsv";
+		case "docbook":
+			return "docbook5";
+		case "epub":
+			return "epub3";
+		case "html":
+			return "html5";
+		case "json":
+			return "json";
+		case "odt":
+			return "odt";
+		case "rst":
+			return "rst";
+		default:
+			throw new Error(`Unsupported pandoc output format: ${ext}`);
+	}
+}
+
+/**
+ * Normalize format aliases to canonical extension names.
+ */
+function normalizeFormat(ext: string): string {
+	if (ext === "markdown") return "md";
+	return ext;
+}
+
+/**
+ * Pandoc-based document converter.
+ *
+ * Uses system `pandoc` via `child_process.execFile`.
+ * Gracefully unavailable if pandoc is not installed.
+ */
+export class PandocNodeConverter implements NodeConverter {
+	readonly name = "pandoc";
+
+	readonly supportedFormats: FormatInfo[] = [
+		new FormatInfo("docx", true, true),
+		// .doc is NOT supported — pandoc docx reader can't handle binary .doc
+		new FormatInfo("md", true, true),
+		new FormatInfo("html", true, true),
+		new FormatInfo("rtf", true, false), // read only — RTF output is blocked
+		new FormatInfo("csv", true, true),
+		new FormatInfo("tsv", true, true),
+		new FormatInfo("json", true, true), // pandoc-converted JSON only
+		new FormatInfo("rst", true, true),
+		new FormatInfo("epub", true, true),
+		new FormatInfo("odt", true, true),
+		new FormatInfo("docbook", true, true),
+	];
+
+	private pandocPath: string | null = null;
+	private available: boolean | null = null;
+	private activeCount = 0;
+
+	/** Detect if pandoc is installed on the system. */
+	async isAvailable(): Promise<boolean> {
+		if (this.available !== null) return this.available;
+
+		try {
+			this.pandocPath = await which("pandoc");
+			this.available = true;
+		} catch {
+			this.available = false;
+			console.error("[pandoc] pandoc not found on system PATH");
+		}
+
+		return this.available;
+	}
+
+	/** Convert a document file using pandoc. */
+	async convert(options: ConvertOptions): Promise<ConvertResult> {
+		if (!(await this.isAvailable()) || !this.pandocPath) {
+			throw new Error("pandoc is not available on this system");
+		}
+
+		if (this.activeCount >= MAX_CONCURRENT) {
+			throw new Error(
+				`Too many concurrent pandoc conversions (max ${MAX_CONCURRENT}). Try again later.`,
+			);
+		}
+
+		const inputExt = path.extname(options.inputPath).slice(1).toLowerCase();
+		const outputExt = normalizeFormat(options.outputFormat.toLowerCase());
+
+		// Block RTF output
+		if (outputExt === "rtf") {
+			throw new Error("Converting to RTF is not supported.");
+		}
+
+		const reader = formatToReader(normalizeFormat(inputExt));
+		const writer = formatToWriter(outputExt);
+
+		// Create temp dir for --extract-media (cleaned in finally)
+		const mediaTmpDir = await mkdtemp(path.join(tmpdir(), "pandoc-media-"));
+
+		this.activeCount++;
+		try {
+			const args: string[] = [
+				"--sandbox",
+				"-f", reader,
+				"-t", writer,
+				"--extract-media", mediaTmpDir,
+				"-o", options.outputPath,
+				"--", options.inputPath,
+			];
+
+			await execFileAsync(this.pandocPath, args, {
+				timeout: TIMEOUT_MS,
+				maxBuffer: 50 * 1024 * 1024, // 50 MB stdout/stderr buffer
+				windowsHide: true,
+			});
+
+			const outputStats = await stat(options.outputPath);
+
+			return {
+				outputPath: options.outputPath,
+				format: outputExt,
+				sizeBytes: outputStats.size,
+			};
+		} finally {
+			this.activeCount--;
+			// Clean up extracted media temp dir
+			try {
+				await rm(mediaTmpDir, { recursive: true, force: true });
+			} catch {
+				// Best-effort cleanup — don't throw from finally
+				console.error(`[pandoc] Failed to clean up temp dir: ${mediaTmpDir}`);
+			}
+		}
+	}
+}

--- a/mcp/src/converters/registry.ts
+++ b/mcp/src/converters/registry.ts
@@ -1,0 +1,176 @@
+import type { FormatInfo, NodeConverter } from "./types.js";
+import { MIME_TYPES } from "./types.js";
+import { MagickNodeConverter } from "./magick.js";
+import { FFmpegNodeConverter } from "./ffmpeg.js";
+import { PandocNodeConverter } from "./pandoc.js";
+
+/** All converter instances, in priority order. */
+const converters: NodeConverter[] = [
+	new MagickNodeConverter(),
+	new FFmpegNodeConverter(),
+	new PandocNodeConverter(),
+];
+
+/** Category definitions. */
+export type Category = "image" | "audio" | "doc";
+
+/**
+ * Build the format allowlist (undotted format names) from all converters.
+ */
+export function buildFormatAllowlist(): Set<string> {
+	const allowlist = new Set<string>();
+	for (const converter of converters) {
+		for (const fmt of converter.supportedFormats) {
+			// Store undotted names
+			const name = fmt.name.startsWith(".") ? fmt.name.slice(1) : fmt.name;
+			allowlist.add(name);
+		}
+	}
+	return allowlist;
+}
+
+/**
+ * Find the appropriate converter for a given input and output format.
+ * Converter priority: magick -> ffmpeg -> pandoc (array order).
+ */
+export function getConverter(
+	inputFormat: string,
+	outputFormat: string,
+): NodeConverter | null {
+	const inputDotted = inputFormat.startsWith(".") ? inputFormat : `.${inputFormat}`;
+	const outputDotted = outputFormat.startsWith(".") ? outputFormat : `.${outputFormat}`;
+
+	for (const converter of converters) {
+		const supportsInput = converter.supportedFormats.some(
+			(f) => f.name === inputDotted && f.fromSupported,
+		);
+		const supportsOutput = converter.supportedFormats.some(
+			(f) => f.name === outputDotted && f.toSupported,
+		);
+		if (supportsInput && supportsOutput) {
+			return converter;
+		}
+	}
+
+	// Fallback: find any converter that handles the output format
+	// (e.g., video input with audio output — ffmpeg handles video input)
+	for (const converter of converters) {
+		const supportsInput = converter.supportedFormats.some(
+			(f) => f.name === inputDotted && f.fromSupported,
+		);
+		if (supportsInput) {
+			// Check if any other converter can handle the output
+			for (const outConverter of converters) {
+				const supportsOutput = outConverter.supportedFormats.some(
+					(f) => f.name === outputDotted && f.toSupported,
+				);
+				if (supportsOutput && converter === outConverter) {
+					return converter;
+				}
+			}
+		}
+	}
+
+	return null;
+}
+
+/**
+ * Get format info by extension (undotted).
+ */
+export function getFormatInfo(format: string): {
+	name: string;
+	fromSupported: boolean;
+	toSupported: boolean;
+	category: Category | null;
+	mimeType: string | null;
+	converter: string | null;
+} | null {
+	const dotted = format.startsWith(".") ? format : `.${format}`;
+	const undotted = format.startsWith(".") ? format.slice(1) : format;
+
+	for (const converter of converters) {
+		const fmt = converter.supportedFormats.find((f) => f.name === dotted);
+		if (fmt) {
+			return {
+				name: undotted,
+				fromSupported: fmt.fromSupported,
+				toSupported: fmt.toSupported,
+				category: getCategory(converter.name),
+				mimeType: MIME_TYPES[undotted] ?? null,
+				converter: converter.name,
+			};
+		}
+	}
+
+	return null;
+}
+
+/**
+ * List formats, optionally filtered by category.
+ */
+export function listFormats(category?: Category): {
+	name: string;
+	fromSupported: boolean;
+	toSupported: boolean;
+	category: Category;
+	mimeType: string | null;
+}[] {
+	const results: {
+		name: string;
+		fromSupported: boolean;
+		toSupported: boolean;
+		category: Category;
+		mimeType: string | null;
+	}[] = [];
+
+	const seen = new Set<string>();
+
+	for (const converter of converters) {
+		const cat = getCategory(converter.name);
+		if (category && cat !== category) continue;
+
+		for (const fmt of converter.supportedFormats) {
+			// Skip video formats (input-only, not shown in list_formats)
+			if (!fmt.isNative && !fmt.toSupported) continue;
+
+			const undotted = fmt.name.startsWith(".") ? fmt.name.slice(1) : fmt.name;
+			if (seen.has(undotted)) continue;
+			seen.add(undotted);
+
+			results.push({
+				name: undotted,
+				fromSupported: fmt.fromSupported,
+				toSupported: fmt.toSupported,
+				category: cat,
+				mimeType: MIME_TYPES[undotted] ?? null,
+			});
+		}
+	}
+
+	return results.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * Check which converters are available on this system.
+ */
+export async function checkAvailability(): Promise<Record<string, boolean>> {
+	const results: Record<string, boolean> = {};
+	for (const converter of converters) {
+		results[converter.name] = await converter.isAvailable();
+	}
+	return results;
+}
+
+/** Map converter name to category. */
+function getCategory(converterName: string): Category {
+	switch (converterName) {
+		case "imagemagick":
+			return "image";
+		case "ffmpeg":
+			return "audio";
+		case "pandoc":
+			return "doc";
+		default:
+			return "image";
+	}
+}

--- a/mcp/src/converters/types.ts
+++ b/mcp/src/converters/types.ts
@@ -1,0 +1,139 @@
+/**
+ * Format metadata for a single file format.
+ * Adapted from VERT's FormatInfo class (converter.svelte.ts).
+ */
+export class FormatInfo {
+	public name: string;
+
+	constructor(
+		name: string,
+		public fromSupported = true,
+		public toSupported = true,
+		public isNative = true,
+	) {
+		this.name = name;
+		if (!this.name.startsWith(".")) {
+			this.name = `.${this.name}`;
+		}
+
+		if (!this.fromSupported && !this.toSupported) {
+			throw new Error("Format must support at least one direction");
+		}
+	}
+}
+
+/** Options passed to a converter's convert method. */
+export interface ConvertOptions {
+	inputPath: string;
+	outputPath: string;
+	outputFormat: string;
+	quality?: number;
+	keepMetadata?: boolean;
+	audioBitrate?: string;
+	sampleRate?: number;
+}
+
+/** Result returned from a successful conversion. */
+export interface ConvertResult {
+	outputPath: string;
+	format: string;
+	sizeBytes: number;
+}
+
+/** Base interface for all converters. */
+export interface NodeConverter {
+	/** Converter name (e.g. "imagemagick", "ffmpeg", "pandoc"). */
+	readonly name: string;
+	/** Supported formats. */
+	readonly supportedFormats: FormatInfo[];
+	/** Whether this converter is available on the system. */
+	isAvailable(): Promise<boolean>;
+	/** Convert a file. */
+	convert(options: ConvertOptions): Promise<ConvertResult>;
+}
+
+/** Common MIME types by extension (undotted). */
+export const MIME_TYPES: Record<string, string> = {
+	// Common image formats
+	png: "image/png",
+	jpg: "image/jpeg",
+	jpeg: "image/jpeg",
+	jpe: "image/jpeg",
+	jfif: "image/jpeg",
+	gif: "image/gif",
+	webp: "image/webp",
+	svg: "image/svg+xml",
+	svgz: "image/svg+xml",
+	bmp: "image/bmp",
+	ico: "image/x-icon",
+	cur: "image/x-icon",
+	tiff: "image/tiff",
+	tif: "image/tiff",
+	avif: "image/avif",
+	heic: "image/heic",
+	heif: "image/heif",
+	jxl: "image/jxl",
+	psd: "image/vnd.adobe.photoshop",
+	hdr: "image/vnd.radiance",
+	exr: "image/x-exr",
+	dds: "image/vnd.ms-dds",
+	pbm: "image/x-portable-bitmap",
+	pgm: "image/x-portable-graymap",
+	ppm: "image/x-portable-pixmap",
+	pnm: "image/x-portable-anymap",
+	pam: "image/x-portable-arbitrarymap",
+	pcx: "image/x-pcx",
+	tga: "image/x-tga",
+	qoi: "image/x-qoi",
+	ani: "application/x-navi-animation",
+	icns: "image/x-icns",
+
+	// Audio formats
+	mp3: "audio/mpeg",
+	wav: "audio/wav",
+	flac: "audio/flac",
+	ogg: "audio/ogg",
+	oga: "audio/ogg",
+	opus: "audio/opus",
+	aac: "audio/aac",
+	m4a: "audio/mp4",
+	m4b: "audio/mp4",
+	wma: "audio/x-ms-wma",
+	amr: "audio/amr",
+	ac3: "audio/ac3",
+	aiff: "audio/aiff",
+	aif: "audio/aiff",
+	aifc: "audio/aiff",
+	au: "audio/basic",
+	mp2: "audio/mpeg",
+	caf: "audio/x-caf",
+	voc: "audio/x-voc",
+	weba: "audio/webm",
+
+	// Document formats
+	docx: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+	md: "text/markdown",
+	html: "text/html",
+	rtf: "application/rtf",
+	csv: "text/csv",
+	tsv: "text/tab-separated-values",
+	json: "application/json",
+	rst: "text/x-rst",
+	epub: "application/epub+zip",
+	odt: "application/vnd.oasis.opendocument.text",
+	docbook: "application/docbook+xml",
+
+	// Video formats (input only for audio extraction)
+	mp4: "video/mp4",
+	mkv: "video/x-matroska",
+	avi: "video/x-msvideo",
+	mov: "video/quicktime",
+	webm: "video/webm",
+	wmv: "video/x-ms-wmv",
+	flv: "video/x-flv",
+	mpg: "video/mpeg",
+	mpeg: "video/mpeg",
+	m4v: "video/mp4",
+	"3gp": "video/3gpp",
+	ogv: "video/ogg",
+};

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -1,0 +1,223 @@
+#!/usr/bin/env node
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+import path from "node:path";
+
+import {
+	validateInputPath,
+	validateOutputPath,
+	validateFormat,
+	validateAudioBitrate,
+	validateSampleRate,
+} from "./security.js";
+import {
+	buildFormatAllowlist,
+	getConverter,
+	getFormatInfo,
+	listFormats,
+	checkAvailability,
+} from "./converters/registry.js";
+
+// Build format allowlist once at startup
+const FORMAT_ALLOWLIST = buildFormatAllowlist();
+
+const server = new McpServer({
+	name: "vert",
+	version: "0.1.0",
+});
+
+// ── convert_file ──────────────────────────────────────────────────────────
+
+server.tool(
+	"convert_file",
+	"Convert a file between formats. Supports 140+ image formats (via ImageMagick WASM), 28+ audio formats (via system ffmpeg), and 11 document formats (via system pandoc). Video input is supported for audio extraction (e.g., MP4 to MP3).",
+	{
+		input_path: z.string().describe("Absolute path to the input file"),
+		output_format: z.string().describe("Target format extension (e.g. \"webp\", \"mp3\", \"docx\")"),
+		output_path: z.string().optional().describe("Output file path. Defaults to input directory with new extension"),
+		quality: z.number().min(1).max(100).optional().describe("Compression quality for lossy image formats (1-100)"),
+		keep_metadata: z.boolean().optional().describe("Preserve file metadata. Defaults to true"),
+		audio_bitrate: z.string().optional().describe("Audio bitrate (e.g. \"128k\", \"320k\")"),
+		sample_rate: z.number().optional().describe("Audio sample rate in Hz (e.g. 44100, 48000)"),
+	},
+	async (params) => {
+		try {
+			// Validate input path
+			const resolvedInput = await validateInputPath(params.input_path);
+
+			// Validate output format
+			const outputFormat = validateFormat(params.output_format, FORMAT_ALLOWLIST);
+
+			// Validate input format
+			const inputExt = path.extname(resolvedInput).slice(1).toLowerCase();
+			if (!inputExt) {
+				return {
+					content: [{ type: "text", text: "Input file has no extension. Cannot determine format." }],
+					isError: true,
+				};
+			}
+			// Input format validation: check it's a known format (but don't block unsupported WASM
+			// formats for input — they may be handled by ffmpeg/pandoc)
+			if (!FORMAT_ALLOWLIST.has(inputExt)) {
+				return {
+					content: [{ type: "text", text: `Unknown input format: ${inputExt}` }],
+					isError: true,
+				};
+			}
+
+			// Determine output path
+			let outputPath: string;
+			if (params.output_path) {
+				outputPath = params.output_path;
+			} else {
+				const dir = path.dirname(resolvedInput);
+				const base = path.basename(resolvedInput, path.extname(resolvedInput));
+				outputPath = path.join(dir, `${base}.${outputFormat}`);
+			}
+
+			// Validate output path
+			const resolvedOutput = await validateOutputPath(outputPath, resolvedInput);
+
+			// Validate optional params
+			if (params.audio_bitrate !== undefined) {
+				validateAudioBitrate(params.audio_bitrate);
+			}
+			if (params.sample_rate !== undefined) {
+				validateSampleRate(params.sample_rate);
+			}
+
+			// Find a converter
+			const converter = getConverter(inputExt, outputFormat);
+			if (!converter) {
+				return {
+					content: [{ type: "text", text: `No converter available for ${inputExt} → ${outputFormat}` }],
+					isError: true,
+				};
+			}
+
+			// Check if the converter is available on this system
+			const available = await converter.isAvailable();
+			if (!available) {
+				return {
+					content: [{
+						type: "text",
+						text: `Converter "${converter.name}" is not available on this system. ${converter.name === "ffmpeg" ? "Install ffmpeg to convert audio files." : converter.name === "pandoc" ? "Install pandoc to convert documents." : ""}`,
+					}],
+					isError: true,
+				};
+			}
+
+			// Run conversion
+			const result = await converter.convert({
+				inputPath: resolvedInput,
+				outputPath: resolvedOutput,
+				outputFormat,
+				quality: params.quality,
+				keepMetadata: params.keep_metadata,
+				audioBitrate: params.audio_bitrate,
+				sampleRate: params.sample_rate,
+			});
+
+			return {
+				content: [{
+					type: "text",
+					text: JSON.stringify({
+						output_path: result.outputPath,
+						format: result.format,
+						size_bytes: result.sizeBytes,
+					}, null, 2),
+				}],
+			};
+		} catch (err) {
+			return {
+				content: [{ type: "text", text: `Conversion failed: ${(err as Error).message}` }],
+				isError: true,
+			};
+		}
+	},
+);
+
+// ── list_formats ──────────────────────────────────────────────────────────
+
+server.tool(
+	"list_formats",
+	"List supported file formats, optionally filtered by category. Returns format name, supported directions, category, and MIME type.",
+	{
+		category: z.enum(["image", "audio", "doc"]).optional().describe(
+			"Filter by category: \"image\", \"audio\", or \"doc\""
+		),
+	},
+	async (params) => {
+		try {
+			const formats = listFormats(params.category);
+			const availability = await checkAvailability();
+
+			return {
+				content: [{
+					type: "text",
+					text: JSON.stringify({
+						converters: availability,
+						formats,
+						total: formats.length,
+					}, null, 2),
+				}],
+			};
+		} catch (err) {
+			return {
+				content: [{ type: "text", text: `Failed to list formats: ${(err as Error).message}` }],
+				isError: true,
+			};
+		}
+	},
+);
+
+// ── get_format_info ───────────────────────────────────────────────────────
+
+server.tool(
+	"get_format_info",
+	"Get detailed information about a specific file format, including supported conversion directions, category, MIME type, and which converter handles it.",
+	{
+		format: z.string().describe("File extension without dot (e.g. \"png\", \"mp3\", \"docx\")"),
+	},
+	async (params) => {
+		try {
+			const normalized = params.format.startsWith(".")
+				? params.format.slice(1).toLowerCase()
+				: params.format.toLowerCase();
+
+			const info = getFormatInfo(normalized);
+			if (!info) {
+				return {
+					content: [{ type: "text", text: `Unknown format: ${normalized}` }],
+					isError: true,
+				};
+			}
+
+			return {
+				content: [{
+					type: "text",
+					text: JSON.stringify(info, null, 2),
+				}],
+			};
+		} catch (err) {
+			return {
+				content: [{ type: "text", text: `Failed to get format info: ${(err as Error).message}` }],
+				isError: true,
+			};
+		}
+	},
+);
+
+// ── Start server ──────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+	const transport = new StdioServerTransport();
+	await server.connect(transport);
+	console.error("[vert-mcp] Server started on stdio");
+}
+
+main().catch((err) => {
+	console.error("[vert-mcp] Fatal error:", err);
+	process.exit(1);
+});

--- a/mcp/src/security.ts
+++ b/mcp/src/security.ts
@@ -1,0 +1,170 @@
+import { stat, realpath, access, constants } from "node:fs/promises";
+import path from "node:path";
+
+/** Dangerous ImageMagick format names that could execute code or fetch URLs. */
+const DANGEROUS_FORMATS = new Set([
+	"mvg", "msl", "ephemeral", "url", "http", "https",
+	"ftp", "text", "label", "caption",
+]);
+
+/** Formats that lack WASM delegates and will fail silently or produce garbage. */
+const UNSUPPORTED_WASM_FORMATS = new Set([
+	"pdf", "pdfa", "eps", "ps", "ps1", "ps2", "ps3",
+	// SVG INPUT is unsupported (needs librsvg), but OUTPUT works via IM's internal writer.
+	// Blocked at the converter level (fromSupported=false) instead of here.
+	// RAW camera formats (need libraw)
+	"cr2", "nef", "arw", "dng", "cr3", "orf", "rw2", "pef",
+	"srf", "sr2", "raf", "mrw", "erf", "kdc", "dcr", "rwl",
+	"iiq", "3fr", "crw", "mef", "nrw", "srw", "mos", "raw",
+	// Old binary .doc (pandoc docx reader can't handle it)
+	"doc",
+]);
+
+/**
+ * Validate and resolve an input file path.
+ * Returns the resolved absolute path.
+ */
+export async function validateInputPath(inputPath: string): Promise<string> {
+	assertNoPathInjection(inputPath);
+
+	const resolved = path.resolve(inputPath);
+	const real = await realpath(resolved);
+
+	const stats = await stat(real);
+	if (!stats.isFile()) {
+		throw new Error(`Input path is not a regular file: ${inputPath}`);
+	}
+
+	// 100 MB limit
+	const MAX_SIZE = 100 * 1024 * 1024;
+	if (stats.size > MAX_SIZE) {
+		throw new Error(
+			`Input file exceeds 100 MB limit: ${(stats.size / 1024 / 1024).toFixed(1)} MB`,
+		);
+	}
+
+	return real;
+}
+
+/**
+ * Validate and resolve an output file path.
+ * Returns the resolved absolute path, ensuring it won't overwrite existing files.
+ */
+export async function validateOutputPath(
+	outputPath: string,
+	inputPath: string,
+): Promise<string> {
+	assertNoPathInjection(outputPath);
+
+	const resolved = path.resolve(outputPath);
+
+	// Verify output !== input after resolution
+	if (resolved === inputPath) {
+		throw new Error("Output path cannot be the same as input path");
+	}
+
+	// Verify parent directory exists and is writable
+	const parentDir = path.dirname(resolved);
+	try {
+		await access(parentDir, constants.W_OK);
+	} catch {
+		throw new Error(`Output directory is not writable: ${parentDir}`);
+	}
+
+	// Don't overwrite existing files — auto-suffix
+	return await findAvailablePath(resolved);
+}
+
+/**
+ * Validate a format string against the allowlist.
+ * Returns the normalized undotted format string.
+ */
+export function validateFormat(format: string, allowlist: Set<string>): string {
+	// Strip leading dot if present
+	const normalized = format.startsWith(".") ? format.slice(1) : format;
+	const lower = normalized.toLowerCase();
+
+	if (DANGEROUS_FORMATS.has(lower)) {
+		throw new Error(`Blocked dangerous format: ${lower}`);
+	}
+
+	if (UNSUPPORTED_WASM_FORMATS.has(lower)) {
+		throw new Error(
+			`Unsupported format: ${lower} (requires system libraries not available in WASM)`,
+		);
+	}
+
+	if (!allowlist.has(lower)) {
+		throw new Error(`Unknown format: ${lower}`);
+	}
+
+	return lower;
+}
+
+/**
+ * Validate audio bitrate parameter.
+ */
+export function validateAudioBitrate(bitrate: string): string {
+	if (!/^\d+k$/.test(bitrate)) {
+		throw new Error(
+			`Invalid audio bitrate: ${bitrate}. Expected format like "128k" or "320k".`,
+		);
+	}
+	return bitrate;
+}
+
+/**
+ * Validate sample rate parameter.
+ */
+export function validateSampleRate(rate: number): number {
+	if (!Number.isInteger(rate) || rate < 8000 || rate > 192000) {
+		throw new Error(
+			`Invalid sample rate: ${rate}. Must be an integer between 8000 and 192000.`,
+		);
+	}
+	return rate;
+}
+
+/** Check for path injection attempts. */
+function assertNoPathInjection(filePath: string): void {
+	// Block null bytes
+	if (filePath.includes("\0")) {
+		throw new Error("Path contains null bytes");
+	}
+
+	// Block Windows UNC paths
+	if (filePath.startsWith("\\\\")) {
+		throw new Error("UNC paths are not allowed");
+	}
+
+	// Block NTFS alternate data streams (colons after drive prefix)
+	// Allow the drive letter colon (e.g., C:\) but block file.txt:stream
+	const withoutDrive = filePath.replace(/^[A-Za-z]:/, "");
+	if (withoutDrive.includes(":")) {
+		throw new Error("NTFS alternate data streams are not allowed");
+	}
+}
+
+/** Find an available path by appending _1, _2, etc. if the file exists. */
+async function findAvailablePath(filePath: string): Promise<string> {
+	try {
+		await stat(filePath);
+	} catch {
+		// File doesn't exist, path is available
+		return filePath;
+	}
+
+	const ext = path.extname(filePath);
+	const base = filePath.slice(0, -ext.length || undefined);
+
+	for (let i = 1; i <= 1000; i++) {
+		const candidate = `${base}_${i}${ext}`;
+		try {
+			await stat(candidate);
+		} catch {
+			return candidate;
+		}
+	}
+
+	throw new Error("Could not find available output path after 1000 attempts");
+}

--- a/mcp/src/util/parse-ani.ts
+++ b/mcp/src/util/parse-ani.ts
@@ -1,0 +1,151 @@
+// THIS CODE IS FROM https://github.com/captbaritone/webamp/blob/15b0312cb794973a0e615d894df942452e920c36/packages/ani-cursor/src/parser.ts
+// LICENSED UNDER MIT. (c) Jordan Eldredge and Webamp contributors
+
+// this code is ripped from their project because i didn't want to
+// re-invent the wheel, BUT the library they provide (ani-cursor)
+// doesn't expose the internals.
+
+import riffFile from "riff-file";
+const { RIFFFile } = riffFile;
+import { unpackArray, unpackString } from "byte-data";
+
+type Chunk = {
+	format: string;
+	chunkId: string;
+	chunkData: {
+		start: number;
+		end: number;
+	};
+	subChunks: Chunk[];
+};
+
+// https://www.informit.com/articles/article.aspx?p=1189080&seqNum=3
+type AniMetadata = {
+	cbSize: number; // Data structure size (in bytes)
+	nFrames: number; // Number of images (also known as frames) stored in the file
+	nSteps: number; // Number of frames to be displayed before the animation repeats
+	iWidth: number; // Width of frame (in pixels)
+	iHeight: number; // Height of frame (in pixels)
+	iBitCount: number; // Number of bits per pixel
+	nPlanes: number; // Number of color planes
+	iDispRate: number; // Default frame display rate (measured in 1/60th-of-a-second units)
+	bfAttributes: number; // ANI attribute bit flags
+};
+
+type ParsedAni = {
+	rate: number[] | null;
+	seq: number[] | null;
+	images: Uint8Array[];
+	metadata: AniMetadata;
+	artist: string | null;
+	title: string | null;
+};
+
+const DWORD = { bits: 32, be: false, signed: false, fp: false };
+
+export function parseAni(arr: Uint8Array): ParsedAni {
+	const riff = new RIFFFile();
+
+	riff.setSignature(arr);
+
+	const signature = riff.signature as Chunk;
+	if (signature.format !== "ACON") {
+		throw new Error(
+			`Expected format. Expected "ACON", got "${signature.format}"`,
+		);
+	}
+
+	// Helper function to get a chunk by chunkId and transform it if it's non-null.
+	function mapChunk<T>(
+		chunkId: string,
+		mapper: (chunk: Chunk) => T,
+	): T | null {
+		const chunk = riff.findChunk(chunkId) as Chunk | null;
+		return chunk == null ? null : mapper(chunk);
+	}
+
+	function readImages(chunk: Chunk, frameCount: number): Uint8Array[] {
+		return chunk.subChunks.slice(0, frameCount).map((c) => {
+			if (c.chunkId !== "icon") {
+				throw new Error(`Unexpected chunk type in fram: ${c.chunkId}`);
+			}
+			return arr.slice(c.chunkData.start, c.chunkData.end);
+		});
+	}
+
+	const metadata = mapChunk("anih", (c) => {
+		const words = unpackArray(
+			arr,
+			DWORD,
+			c.chunkData.start,
+			c.chunkData.end,
+		);
+		return {
+			cbSize: words[0],
+			nFrames: words[1],
+			nSteps: words[2],
+			iWidth: words[3],
+			iHeight: words[4],
+			iBitCount: words[5],
+			nPlanes: words[6],
+			iDispRate: words[7],
+			bfAttributes: words[8],
+		};
+	});
+
+	if (metadata == null) {
+		throw new Error("Did not find anih");
+	}
+
+	const rate = mapChunk("rate", (c) => {
+		return unpackArray(arr, DWORD, c.chunkData.start, c.chunkData.end);
+	});
+	// chunkIds are always four chars, hence the trailing space.
+	const seq = mapChunk("seq ", (c) => {
+		return unpackArray(arr, DWORD, c.chunkData.start, c.chunkData.end);
+	});
+
+	const lists = riff.findChunk("LIST", true) as Chunk[] | null;
+	const imageChunk = lists?.find((c) => c.format === "fram");
+	if (imageChunk == null) {
+		throw new Error("Did not find fram LIST");
+	}
+
+	let images = readImages(imageChunk, metadata.nFrames);
+
+	let title = null;
+	let artist = null;
+
+	const infoChunk = lists?.find((c) => c.format === "INFO");
+	if (infoChunk != null) {
+		infoChunk.subChunks.forEach((c) => {
+			switch (c.chunkId) {
+				case "INAM":
+					title = unpackString(
+						arr,
+						c.chunkData.start,
+						c.chunkData.end,
+					);
+					break;
+				case "IART":
+					artist = unpackString(
+						arr,
+						c.chunkData.start,
+						c.chunkData.end,
+					);
+					break;
+				case "LIST":
+					// Some cursors with an artist of "Created with Take ONE 3.5 (unregisterred version)" seem to have their frames here for some reason?
+					if (c.format === "fram") {
+						images = readImages(c, metadata.nFrames);
+					}
+					break;
+
+				default:
+				// Unexpected subchunk
+			}
+		});
+	}
+
+	return { images, rate, seq, metadata, artist, title };
+}

--- a/mcp/tsconfig.json
+++ b/mcp/tsconfig.json
@@ -1,0 +1,15 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"strict": true,
+		"esModuleInterop": true,
+		"declaration": true,
+		"resolveJsonModule": true,
+		"skipLibCheck": true
+	},
+	"include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary

- Adds `mcp/` directory: a standalone stdio MCP server that exposes VERT's file conversion to Claude Code (and any MCP client)
- 140+ image formats via `@imagemagick/magick-wasm` (runs in Node.js, no system deps)
- 28+ audio formats via system `ffmpeg` (gracefully unavailable if not installed)
- 11 document formats via system `pandoc` (gracefully unavailable if not installed)
- Video input supported for audio extraction (e.g., MP4→MP3)
- Three tools: `convert_file`, `list_formats`, `get_format_info`

## Transparency

This code was written by Claude (Opus 4.6). I tested it and use the MCP server personally — it works. However, I didn't read the code myself, so I wouldn't ask you to merge code I haven't reviewed. Instead, I'm sharing the plan/spec I wrote and verified so you can run it yourselves and generate your own code from it. The code in this PR is just a reference for what the plan produces.

<details>
<summary>Full plan/prompt (click to expand)</summary>

# VERT MCP Server

## Context

VERT (vert.sh) is an open-source file converter supporting 250+ formats. It's a static website — all conversion runs client-side via WASM in the browser, no server API exists. We're building a standalone MCP server that runs `@imagemagick/magick-wasm` in Node.js (confirmed working — official demo is a Node.js script, CI tests on Node 18/20/22), and shells out to system `ffmpeg`/`pandoc` for audio/docs. PRed to VERT-sh/VERT as `mcp/`.

Scope: images, audio, and documents. No video output (vertd is a separate remote service). Video INPUT is allowed for audio extraction (e.g., MP4→MP3 via ffmpeg `-map 0:a:0`).

## Corrections from Verification (Rounds 4-9)

All issues found during verification. Every item is addressed in the plan below.

1. **Bump magick-wasm to 0.0.38** (latest, released Jan 29 2026)
2. **Require Node 18+** — No longer need Node 20. Switched from client-zip (needs `File` global) to yazl (pure Node.js). All other APIs (Response, ReadableStream, Blob) available in Node 18+.
3. **Use callback-based disposal** — `ImageMagick.read(bytes, img => {...})` auto-disposes after callback. `ImageMagick.readCollection(bytes, imgs => {...})` for animated GIF/WebP. Both ensure cleanup even on exceptions.
4. **Add missing FFmpeg codec mappings** — amr→libopencore_amrnb, ac3→ac3, aiff→pcm_s16be, aifc→pcm_s16be, aif→pcm_s16be, au→pcm_mulaw, voc→pcm_u8, weba→libopus, mp2→mp2, caf→pcm_s16le, m4b→aac (11 total)
5. **Opus 44100→48000 fix** — Opus doesn't support 44100Hz. Auto-adjust to 48000Hz. Also default 48000 for lossless→opus path.
6. **ALAC output extension** — output_format="alac" → file ext `.m4a`, codec `alac`.
7. **Remove .doc from pandoc** — Pandoc's `docx` reader can't handle old binary `.doc` files.
8. **RTF output = false** — VERT blocks RTF output at runtime. Set `toSupported: false` in registry. (Note: pandoc CAN write RTF, but VERT chose to block it. We follow VERT's decision.)
9. **Pandoc formatToWriter()** — Separate writer mapping. Key differences: epub→`epub3`, docbook→`docbook5` (pandoc's bare `docbook` writer defaults to v4, not v5). html→`html5` (default, same as bare `html`).
10. **Pandoc --sandbox flag** — ALWAYS pass `--sandbox` to prevent file inclusion attacks (\input{}, .. include::), SSRF via iframe fetching, and data exfiltration via image embedding. Does NOT restrict the conversion itself, only IO side-effects.
11. **Pandoc --extract-media** — Must use temp dir via `fs.mkdtempSync()`, clean up in finally block.
12. **ANI error fall-through** — VERT's catch block (magick.ts:156-158) falls through silently. Return explicit error.
13. **FormatInfo has no MIME field** — Build extension→MIME lookup table for get_format_info tool.
14. **WASM path resolution** — `createRequire(import.meta.url).resolve('@imagemagick/magick-wasm/magick.wasm')`.
15. **Unsupported WASM formats** — Block: PDF/PDFA, EPS, PS/PS1, RAW camera (CR2, NEF, ARW, DNG, ~18 formats total). These lack WASM delegates. **SVG/SVGZ: block INPUT only** (needs librsvg to read). SVG OUTPUT works via ImageMagick's internal SVG writer (embeds raster as base64). Do NOT put svg/svgz in the blanket `UNSUPPORTED_WASM_FORMATS` security set — that blocks both directions. Instead, register svg/svgz in magick.ts as `fromSupported=false, toSupported=true` so the converter-level check handles input blocking.
16. **Replace client-zip with yazl** — client-zip is browser-first (returns web Response, no Node.js tests). yazl is pure Node.js, 1 dep (buffer-crc32), 58.7kB, streaming API.
17. **Pandoc security: no Lua filters** — Never accept user-supplied Lua filters. Never use --lua-filter with untrusted input.
18. **Missing @types/yazl** — Add `"@types/yazl": "^2"` to devDependencies. yazl is CJS with no built-in types.
19. **write() data must be copied** — magick-wasm's `image.write(fmt, data => {...})` gives a WASM memory view. Must `Buffer.from(data)` to copy before the callback returns and memory is freed. Without this, output files will be corrupted.
20. **MagickFormat casing** — PascalCase keys (`MagickFormat.Png`), UPPERCASE string values (`"PNG"`). Dynamic format: `ext.toUpperCase() as unknown as MagickFormat`. Watch `WebP` (capital P), `APng`.
21. **yazl ESM import** — CJS package, import via `import yazl from "yazl"` then `new yazl.ZipFile()`. Named imports may not work reliably.
22. **Format allowlist dot-prefix** — Security allowlist stores UNDOTTED names (user-facing). Registry lookup prepends `.` for FormatInfo matching. Tool handler strips leading dot from user input before validation.
23. **isNative field** — Defaults to `true` for all MCP formats (no video). Retained in FormatInfo type for VERT compatibility.
24. **Settings→params mapping** — VERT's `ffmpegQuality` = MCP's `audio_bitrate` (used as `-b:a ${value}k`, it's a bitrate NOT quality). `ffmpegSampleRate`/`ffmpegCustomSampleRate` = `sample_rate`. `metadata` = `keep_metadata`.
25. **Video-to-audio extraction** — ALLOW video input files when output is an audio format. System ffmpeg handles this trivially via `-map 0:a:0`. Useful feature (e.g., MP4→MP3).
26. **ICO frame reading** — Use `ImageMagick.read(bytes, new MagickReadSettings({ format: MagickFormat.Ico, frameIndex: i }), img => {...})` callback pattern. Avoids manual create/dispose.
27. **`.fit` → `.fits` bidirectional** — Normalize both input AND output. `.fit` is not a valid MagickFormat; `.fits` is.
28. **`.markdown` alias** — Add `.markdown` → `markdown` reader mapping in pandoc. Normalize to `.md` in registry.
29. **package.json complete** — Must include: name, version, type, bin, files, scripts, license, repository.
30. **tsconfig complete** — Must include: `esModuleInterop: true` (CJS packages), `moduleResolution: "NodeNext"`, `outDir: "./dist"`, `rootDir: "./src"`, `declaration: true`. All relative imports must use `.js` extensions.
31. **Build tool = tsc** — `bun build` breaks on shebangs. Use plain `tsc`. Scripts: `"build": "tsc"`.
32. **bin = dist/index.js** — Compiled output, not source. tsc preserves shebangs natively.
33. **riff-file import fix** — CJS package uses `export = riffFile`. Under NodeNext, `import { RIFFFile } from "riff-file"` fails. Must use `import riffFile from "riff-file"; const { RIFFFile } = riffFile;`. ANI parser is NOT "copy verbatim" — imports need adaptation.
34. **Video input registry** — Video formats are recognized as valid INPUT by FFmpeg for audio extraction, but NOT registered as output-capable. `toSupported: false`. Not shown in `list_formats`; handled as recognized input extensions only.
35. **Verification uses npm** — Use `npm install && npm run build` (not `bun install`) since this is an npm-published package.
36. **magick-automated.ts import fix** — Not "copy verbatim". Has `import { FormatInfo } from "./converter.svelte"` → needs `from "./types.js"`.
37. **Windows ADS colon check** — Don't block ALL colons (breaks `C:\`). Only block colons AFTER the drive prefix (`file.txt:stream`).
38. **which version → ^3.0.0** — Matches `@types/which: ^3`. v4 removed callback API and has no types. Promise API identical in both.
39. **License SPDX** — `AGPL-3.0` → `AGPL-3.0-only` (deprecated identifier causes npm warnings).

## Architecture

Standalone Node.js stdio MCP server. Three converters:

- **ImageMagick** — `@imagemagick/magick-wasm` 0.0.38 in Node.js. 140+ image formats (excluding PDF/EPS/PS/RAW which lack WASM delegates; SVG input blocked but SVG output supported). WASM loaded via `readFileSync` + `createRequire().resolve()`. Lazy init on first call. Serialized queue (single WASM instance). Uses callback-based auto-disposal: `ImageMagick.read()` for single images, `ImageMagick.readCollection()` for animated GIF/WebP.
- **FFmpeg** — system `ffmpeg`/`ffprobe` via `child_process.execFile`. Audio formats. Gracefully unavailable if not installed.
- **Pandoc** — system `pandoc` via `child_process.execFile`. Document formats. Gracefully unavailable if not installed.

## MCP Tools (via `server.registerTool()`, SDK v1.27.0)

### `convert_file`
| Param | Type | Required | Description |
|-------|------|----------|-------------|
| input_path | string | yes | Absolute path to input file |
| output_format | string | yes | Target format (e.g. "webp", "mp3", "docx") |
| output_path | string | no | Output path. Default: input dir + new extension |
| quality | number (1-100) | no | Compression quality for lossy formats |
| keep_metadata | boolean | no | Preserve metadata. Default: true |
| audio_bitrate | string | no | e.g. "128k", "320k" |
| sample_rate | number | no | Audio sample rate in Hz |

Returns: `{ output_path, format, size_bytes }` as JSON text. Errors: `isError: true` with descriptive message.

`inputSchema` accepts raw Zod shape object OR `z.object()` (both work since SDK v1.21.1+). Each tool gets a `title` field.

### `list_formats`
| Param | Type | Required | Description |
|-------|------|----------|-------------|
| category | string | no | "image", "audio", "doc" |

### `get_format_info`
| Param | Type | Required | Description |
|-------|------|----------|-------------|
| format | string | yes | Extension e.g. "png" (no dot) |

## Security

### P0 — Path Validation
- Resolve all paths to absolute via `path.resolve()` + `fs.realpath()`
- Verify `input_path` exists and is a regular file (not symlink to sensitive location)
- Verify `output_path` parent directory exists and is writable
- Block null bytes, Windows UNC paths (`\\\\`), NTFS alternate data streams (colons AFTER the `X:\` drive prefix, e.g., `file.txt:hidden` — do NOT block the drive letter colon itself)
- Refuse to overwrite existing files (or auto-suffix `_1`, `_2`)
- Verify `output_path !== input_path` after resolution

### P0 — Format Validation
- Validate `output_format` against the known format allowlist (registry)
- Block dangerous ImageMagick format names: MVG, MSL, EPHEMERAL, URL, HTTP, HTTPS, FTP, TEXT, LABEL, CAPTION
- Validate input file extension against known formats
- `audio_bitrate` must match regex `^\d+k$`
- `sample_rate` must be a positive integer in a sensible range (8000-192000)

### P0 — Command Injection Prevention
- `execFile` (not `exec`) — no shell metacharacter expansion
- Prefix file paths with `./` or use `--` separator to prevent `-` flag injection
- FFmpeg: add `-protocol_whitelist file,pipe` to block SSRF via http/ftp protocols
- Pandoc: ALWAYS pass `--sandbox` to block file inclusion (\input{}, .. include::, #+INCLUDE:), SSRF via iframe, and data exfiltration via image embedding
- Pandoc: NEVER accept Lua filters or custom writers from user input
- All arguments built as string arrays, never concatenated

### P1 — Resource Limits
- Input file size limit: 100 MB
- Conversion timeout: 120 seconds (configurable)
- ICO/ANI frame count cap: 256
- Max concurrent ffmpeg/pandoc processes: 3

### P1 — Temp Files
- Use `fs.mkdtempSync()` for unique temp dirs
- Clean up in `finally` blocks
- Register `process.on("exit")` handler for crash cleanup
- Use stdin/stdout pipes with ffmpeg/pandoc where possible to avoid temp files

### P1 — Pandoc Security & Temp Files
- ALWAYS pass `--sandbox` — blocks file inclusion, SSRF, data exfiltration
- NEVER use `--lua-filter` or custom writers with untrusted input
- `--extract-media` must point to a temp dir created via `fs.mkdtempSync()`, NOT `.` (current dir)
- Clean up extracted media in `finally` block after conversion
- Prefer `commonmark` reader over `markdown` for untrusted input (more DoS-resistant)

### P2 — WASM Resilience
- Reinitialize WASM instance if a conversion causes an unhandled error (prevents corrupted state)
- Pin `@imagemagick/magick-wasm` to exact 0.0.38 (no `^`). Zero runtime deps = minimal supply chain risk.

## File Structure

```
mcp/
├── package.json
├── tsconfig.json
├── README.md
└── src/
    ├── index.ts              # #!/usr/bin/env node — McpServer + StdioServerTransport + registerTool()
    ├── security.ts           # Path validation, format allowlist, param sanitization
    ├── converters/
    │   ├── types.ts          # FormatInfo, ConvertOptions, ConvertResult, NodeConverter base
    │   ├── registry.ts       # Categories (image/audio/doc), format lookup, converter selection
    │   ├── magick.ts         # ImageMagick WASM — lazy init via readFileSync, queue, callback auto-disposal
    │   ├── ffmpeg.ts         # System ffmpeg/ffprobe — execFile, protocol whitelist, arg arrays
    │   └── pandoc.ts         # System pandoc — execFile, RTF output blocked
    └── util/
        └── parse-ani.ts      # ANI frame parser (from VERT, MIT license attribution preserved)
```

## Dependencies

```json
{
  "name": "@vert-sh/mcp-server",
  "version": "0.1.0",
  "type": "module",
  "bin": "./dist/index.js",
  "files": ["dist/"],
  "license": "AGPL-3.0-only",
  "repository": { "type": "git", "url": "https://github.com/VERT-sh/VERT", "directory": "mcp" },
  "scripts": {
    "build": "tsc",
    "start": "node dist/index.js",
    "prepublishOnly": "tsc"
  },
  "dependencies": {
    "@modelcontextprotocol/sdk": "1.27.0",
    "@imagemagick/magick-wasm": "0.0.38",
    "zod": "^3.25.0",
    "riff-file": "1.0.3",
    "byte-data": "19.0.1",
    "yazl": "3.3.1",
    "which": "^3.0.0"
  },
  "devDependencies": {
    "@types/node": "^22",
    "@types/which": "^3",
    "@types/yazl": "^2",
    "typescript": "^5.9.3"
  },
  "engines": {
    "node": ">=18.0.0"
  }
}
```

**tsconfig.json:**
```json
{
  "compilerOptions": {
    "target": "ES2022",
    "module": "NodeNext",
    "moduleResolution": "NodeNext",
    "outDir": "./dist",
    "rootDir": "./src",
    "strict": true,
    "esModuleInterop": true,
    "declaration": true,
    "resolveJsonModule": true,
    "skipLibCheck": true
  },
  "include": ["src/**/*"]
}
```

Notes:
- Build tool is `tsc` (not `bun build` — shebang parse error). tsc preserves shebangs natively.
- `esModuleInterop: true` required for CJS packages (yazl, riff-file, byte-data).
- `moduleResolution: "NodeNext"` requires `.js` extensions on all relative imports (e.g., `import { foo } from "./security.js"`).
- `@imagemagick/magick-wasm` pinned to 0.0.38 (latest, Jan 2026). Zero runtime deps.
- `riff-file`, `byte-data`, `yazl` pinned to exact versions (no `^`).
- `@modelcontextprotocol/sdk` pinned to exact 1.27.0 (v2 is pre-alpha, not on npm yet).

## What to Reuse from VERT

### Copy and adapt imports
- `src/lib/converters/magick-automated.ts` — 140+ image FormatInfo entries. Fix: `import { FormatInfo } from "./converter.svelte"` → `import { FormatInfo } from "./types.js"`
- `src/lib/util/parse/ani.ts` — ANI parser (preserve MIT attribution comment). Fix: `import riffFile from "riff-file"; const { RIFFFile } = riffFile;` (CJS `export =` incompatible with ESM named import under NodeNext).

### Copy and strip Svelte (.svelte.ts → .ts, remove $state/$derived)
- `FormatInfo` class from `src/lib/converters/converter.svelte.ts` lines 5-23
- Image format list from `src/lib/converters/magick.svelte.ts` lines 19-78
- Audio format list from `src/lib/converters/ffmpeg.svelte.ts` lines 43-74
- Document format list from `src/lib/converters/pandoc.svelte.ts` lines 132-145
- Category system from `src/lib/converters/index.ts` (categories: image, audio, doc)

### Extract and adapt
- `magickConvert()` from `src/lib/workers/magick.ts` lines 287-326 — use callback-based `ImageMagick.read(bytes, img => {...})` for auto-disposal
- ICO multi-image from `src/lib/workers/magick.ts` lines 61-120 — cap at 256 frames, yazl for ZIP output. Use `ImageMagick.read(bytes, new MagickReadSettings({ format: MagickFormat.Ico, frameIndex: i }), img => {...})` per-frame callback (NOT MagickImage.create).
- ANI frame extraction from `src/lib/workers/magick.ts` lines 121-158 — cap frames, FIX: add explicit error return in catch block (source falls through silently)
- Animated GIF/WebP via `ImageMagick.readCollection()` callback pattern from `src/lib/workers/magick.ts` lines 220-242
- Format normalization (.jfif→.jpeg, .fit→.fits) from `src/lib/workers/magick.ts` lines 52-56 — apply BIDIRECTIONALLY (both input and output). Add .markdown→.md for pandoc.
- ICO 256x256 clamp from `src/lib/workers/magick.ts` lines 297-309
- `getCodecs()` from `src/lib/converters/ffmpeg.svelte.ts` lines 636-699 — ADD missing codecs: amr, ac3, aiff, aifc, aif, au, voc, weba, mp2, caf, m4b (11 total)
- `buildConversionCommand()` from `src/lib/converters/ffmpeg.svelte.ts` lines 315-527 — ADD Opus 44100→48000 fix (lines 411-418), ALAC→.m4a mapping (lines 111-113)
- `formatToReader()` from `src/lib/workers/pandoc.ts` lines 92-121 — ADD separate `formatToWriter()` (epub→epub3, docbook→docbook5, html→html5)
- Replace `Blob` concatenation (line 279) with `Buffer.concat()` for Node.js efficiency
- All `image.write(fmt, data => {...})` calls MUST copy data via `Buffer.from(data)` — the callback receives a WASM memory view that becomes invalid after disposal

### Cannot reuse
- `svgToImage()` — Canvas/DOM. SVG-from-input unsupported in v1.
- `@ffmpeg/ffmpeg` — blocks Node.js with explicit error. Entire ffmpeg.svelte.ts file uses browser WASM API. Only reuse format lists and codec logic, NOT imports.
- `vert-wasm` ICNS parser — bare WASM import needs bundler. Skip ICNS for v1.
- `pandoc.ts` WASI shim — runs pandoc as WASM via `@bjorn3/browser_wasi_shim`. MCP uses system binary instead.

### Formats to block (no WASM delegates / unsupported)
- PDF, PDFA, EPS, PS, PS1 (need Ghostscript)
- SVG, SVGZ **input only** (needs librsvg to read). SVG/SVGZ output is allowed — ImageMagick's internal writer works without librsvg. Register as `fromSupported=false, toSupported=true` in magick.ts, NOT in the `UNSUPPORTED_WASM_FORMATS` security blocklist (which would block both directions).
- RAW camera (~18 formats): CR2, NEF, ARW, DNG, CR3, ORF, RW2, PEF, SRF, SR2, RAF, MRW, ERF, KDC, DCR, RWL, IIQ, 3FR (need libraw)
- .doc (old binary format — pandoc docx reader can't handle it)

## Coding Standards (matching VERT)
- Tabs (4-width), double quotes, strict TypeScript
- camelCase functions/variables, PascalCase classes
- JSDoc on public APIs
- `console.error()` for all logging
- AGPL-3.0 license

## Implementation Steps

1. **Scaffold** — `mcp/` with complete package.json (name, version, type: module, bin: dist/index.js, files, scripts: build=tsc, license: AGPL-3.0), tsconfig (ES2022, NodeNext, strict, esModuleInterop, outDir/rootDir), shebang entry point. All relative imports use `.js` extensions.
2. **Security module** — path validation, format allowlist, param sanitization, dangerous format blocklist
3. **Types** — FormatInfo, ConvertOptions, ConvertResult, NodeConverter base class
4. **ImageMagick converter** — `createRequire().resolve()` + `readFileSync` WASM loading, lazy singleton, conversion queue, callback-based auto-disposal, ICO/ANI with frame caps (ANI: fix silent fall-through), block PDF/EPS/SVG/RAW formats, quality + metadata
5. **FFmpeg converter** — `which` detection, getCodecs() with ALL codec mappings (including 11 missing ones), buildConversionCommand() with Opus 44100→48000 fix + ALAC→.m4a mapping, execFile with protocol whitelist + `--` separator, timeout
6. **Pandoc converter** — `which` detection, formatToReader() + formatToWriter() (separate mappings), RTF output blocked, .doc removed, ALWAYS pass --sandbox, --extract-media to temp dir (cleaned in finally), timeout
7. **Registry** — categories (image/audio/doc), format lookup, converter priority (magick → ffmpeg → pandoc)
8. **MCP entry** — McpServer + StdioServerTransport, registerTool() with Zod raw shapes + title fields, security validation on every call, isError handling, format normalization (strip leading dot from user input → validate against undotted allowlist → prepend `.` for FormatInfo lookup)
9. **ANI parser** — copy from VERT with MIT attribution
10. **MIME lookup table** — extension→MIME mapping for get_format_info tool (FormatInfo class has no mime field)
11. **README** — install (npx + manual), Claude Code config JSON, supported formats, requirements (Node 18+, optional ffmpeg/pandoc), security notes

## Verification

1. `cd mcp && npm install && npm run build` — compiles cleanly with tsc
2. `echo '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | node dist/index.js` — returns 3 tools
3. Image: convert PNG → WebP via Claude Code
4. Audio: convert MP3 → WAV (requires system ffmpeg)
5. Document: convert MD → HTML (requires system pandoc)
6. Graceful fallback: list_formats without ffmpeg installed omits audio
7. Error: unsupported format returns descriptive isError message
8. Security: path traversal attempt (`../../../etc/passwd`) rejected
9. Security: format injection (`MVG`) rejected
10. Memory: convert 10 images sequentially, verify no heap growth
11. Timeout: large file conversion respects 120s limit

</details>

## Test plan

- [x] `npm install && npm run build` — zero errors
- [x] MCP server starts and returns 3 tools via `tools/list`
- [x] PNG → WebP (ImageMagick WASM)
- [x] PNG → SVG (ImageMagick WASM, raster embed)
- [x] WAV → MP3, FLAC, Opus (system ffmpeg)
- [x] Opus 44100→48000 auto-adjustment
- [x] Dangerous format (MVG) blocked
- [x] NTFS alternate data stream path injection blocked
- [x] SVG input correctly rejected ("No converter available")
- [x] `list_formats` returns correct counts and availability
- [x] `get_format_info` returns category, MIME type, converter name
- [x] Works as a real MCP tool in Claude Code via `.mcp.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
