### PR TITLE
fix: better visibility for the last lines of texts in card containers

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -275,6 +275,7 @@
 												</span>
 											{/each}
 										</p>
+										<p><br /></p>
 									</div>
 								</div>
 							</OverlayScrollbarsComponent>


### PR DESCRIPTION
In the card containers about supported formats, the last lines are partially blurred when you scroll to the bottom, causing minor visibility issues. I've added a line break at the end, this is the most concise fix I can think of.

Before:
<img width="672" height="362" alt="VERT before 1" src="https://github.com/user-attachments/assets/4e69b280-65ee-4b13-84ed-b187839c7c64" />
After Fix:
<img width="673" height="360" alt="VERT after" src="https://github.com/user-attachments/assets/b3758c93-531b-4414-9381-6b1a8620577e" />

