### PR TITLE
fix: ignore macOS zip metadata entries

### DIFF
--- a/src/lib/util/zip.ts
+++ b/src/lib/util/zip.ts
@@ -41,9 +41,11 @@ export async function createZip(files: File[]): Promise<Uint8Array> {
 }
 
 export function ignoreEntry(filename: string): boolean {
+	const segments = filename.split("/");
 	return (
-		filename.startsWith(".") ||
-		filename.includes("/__MACOSX/") ||
-		filename.endsWith("/")
+		filename.endsWith("/") ||
+		segments.some(
+			(segment) => segment === "__MACOSX" || segment.startsWith("."),
+		)
 	);
 }


### PR DESCRIPTION
## Summary

- ignore `__MACOSX` entries regardless of whether the directory is at the zip root or nested
- ignore dot-prefixed metadata files in nested directories as well as at the root

## Why

macOS archives often include entries like `__MACOSX/._image.png`. The previous check only matched `"/__MACOSX/"`, so root-level `__MACOSX/...` entries could be treated as real files and passed into the conversion flow.

## Testing

- `bunx eslint src/lib/util/zip.ts`
- `bun run build`