### PR TITLE
fix: preserve decoded image depth and indexed transparency

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"format": "prettier --write .",
-		"lint": "prettier --check . && eslint ."
+		"lint": "prettier --check . && eslint .",
+		"test": "node --test --test-concurrency=1 tests/*.test.mjs"
 	},
 	"devDependencies": {
 		"@inlang/paraglide-js": "^2.5.0",

--- a/src/lib/util/magick-convert.ts
+++ b/src/lib/util/magick-convert.ts
@@ -1,0 +1,42 @@
+import { MagickFormat, type IMagickImage } from "@imagemagick/magick-wasm";
+
+export const magickConvert = async (
+	img: IMagickImage,
+	to: string,
+	keepMetadata: boolean,
+	compression?: number,
+) => {
+	let fmt = to.slice(1).toUpperCase();
+	if (fmt === "JFIF") fmt = "JPEG";
+
+	// ICO size clamp to avoid WidthOrHeightExceedsLimit
+	if (fmt === "ICO") {
+		const max = 256;
+		const w = img.width;
+		const h = img.height;
+
+		if (w > max || h > max) {
+			const scale = max / Math.max(w, h);
+			const newW = Math.max(1, Math.round(w * scale));
+			const newH = Math.max(1, Math.round(h * scale));
+
+			img.resize(newW, newH);
+		}
+	}
+
+	const result = await new Promise<Uint8Array>((resolve, reject) => {
+		try {
+			// magick-wasm automatically clamps (https://github.com/dlemstra/magick-wasm/blob/76fc6f2b0c0497d2ddc251bbf6174b4dc92ac3ea/src/magick-image.ts#L2480)
+			if (compression) img.quality = compression;
+			if (!keepMetadata) img.strip();
+
+			img.write(fmt as unknown as MagickFormat, (o: Uint8Array) => {
+				resolve(structuredClone(o));
+			});
+		} catch (error) {
+			reject(error);
+		}
+	});
+
+	return result;
+};

--- a/src/lib/util/magick-convert.ts
+++ b/src/lib/util/magick-convert.ts
@@ -1,4 +1,9 @@
-import { MagickFormat, type IMagickImage } from "@imagemagick/magick-wasm";
+import {
+	ColorType,
+	Quantum,
+	MagickFormat,
+	type IMagickImage,
+} from "@imagemagick/magick-wasm";
 
 export const magickConvert = async (
 	img: IMagickImage,
@@ -29,6 +34,22 @@ export const magickConvert = async (
 			// magick-wasm automatically clamps (https://github.com/dlemstra/magick-wasm/blob/76fc6f2b0c0497d2ddc251bbf6174b4dc92ac3ea/src/magick-image.ts#L2480)
 			if (compression) img.quality = compression;
 			if (!keepMetadata) img.strip();
+
+			// Source depth can describe palette indices or exceed the WASM quantum depth.
+			// Channel values (including alpha) need at least 8 bits after decoding.
+			img.depth = Math.min(Quantum.depth, Math.max(8, img.depth));
+			if (
+				fmt === "PSD" &&
+				img.hasAlpha &&
+				[
+					ColorType.Palette,
+					ColorType.PaletteAlpha,
+					ColorType.PaletteBilevelAlpha,
+				].some((type) => type === img.colorType)
+			) {
+				// The PSD writer cannot encode indexed images with an alpha channel.
+				img.colorType = ColorType.TrueColorAlpha;
+			}
 
 			img.write(fmt as unknown as MagickFormat, (o: Uint8Array) => {
 				resolve(structuredClone(o));

--- a/src/lib/util/magick-convert.ts
+++ b/src/lib/util/magick-convert.ts
@@ -36,8 +36,16 @@ export const magickConvert = async (
 			if (!keepMetadata) img.strip();
 
 			// Source depth can describe palette indices or exceed the WASM quantum depth.
-			// Channel values (including alpha) need at least 8 bits after decoding.
-			img.depth = Math.min(Quantum.depth, Math.max(8, img.depth));
+			// Keep valid packed TIFF samples; palette indices alone cannot tell us
+			// whether the decoded RGB/alpha channels fit in that source depth.
+			const preserveTiffDepth =
+				(fmt === "TIFF" || fmt === "TIF") &&
+				img.depth < 8 &&
+				img.determineBitDepth() <= img.depth;
+			img.depth = Math.min(
+				Quantum.depth,
+				Math.max(preserveTiffDepth ? img.depth : 8, img.depth),
+			);
 			if (
 				fmt === "PSD" &&
 				img.hasAlpha &&

--- a/src/lib/workers/magick.ts
+++ b/src/lib/workers/magick.ts
@@ -4,8 +4,8 @@ import {
 	MagickImage,
 	MagickImageCollection,
 	MagickReadSettings,
-	type IMagickImage,
 } from "@imagemagick/magick-wasm";
+import { magickConvert } from "$lib/util/magick-convert";
 import { makeZip } from "client-zip";
 import { parseAni } from "$lib/util/parse/ani";
 import { parseIcns } from "vert-wasm";
@@ -282,47 +282,6 @@ const readToEnd = async (reader: ReadableStreamDefaultReader<Uint8Array>) => {
 	);
 	const arrayBuffer = await blob.arrayBuffer();
 	return new Uint8Array(arrayBuffer);
-};
-
-const magickConvert = async (
-	img: IMagickImage,
-	to: string,
-	keepMetadata: boolean,
-	compression?: number,
-) => {
-	let fmt = to.slice(1).toUpperCase();
-	if (fmt === "JFIF") fmt = "JPEG";
-
-	// ICO size clamp to avoid WidthOrHeightExceedsLimit
-	if (fmt === "ICO") {
-		const max = 256;
-		const w = img.width;
-		const h = img.height;
-
-		if (w > max || h > max) {
-			const scale = max / Math.max(w, h);
-			const newW = Math.max(1, Math.round(w * scale));
-			const newH = Math.max(1, Math.round(h * scale));
-
-			img.resize(newW, newH);
-		}
-	}
-
-	const result = await new Promise<Uint8Array>((resolve, reject) => {
-		try {
-			// magick-wasm automatically clamps (https://github.com/dlemstra/magick-wasm/blob/76fc6f2b0c0497d2ddc251bbf6174b4dc92ac3ea/src/magick-image.ts#L2480)
-			if (compression) img.quality = compression;
-			if (!keepMetadata) img.strip();
-
-			img.write(fmt as unknown as MagickFormat, (o: Uint8Array) => {
-				resolve(structuredClone(o));
-			});
-		} catch (error) {
-			reject(error);
-		}
-	});
-
-	return result;
 };
 
 onmessage = async (e) => {

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,7 @@
+# Image conversion regression tests
+
+Run `bun install --frozen-lockfile`, then `bun run test` (Node.js 20+).
+
+These tests initialize the installed ImageMagick WASM module and invoke the same `magickConvert` function used by the worker. Fixtures are generated in memory. Encoded outputs are decoded again to inspect dimensions, pixels and metadata; no network service or user images are required.
+
+`helpers-load-ts.mjs` transpiles the small TypeScript utility and its relative imports using the existing TypeScript dependency. The test command runs files sequentially to limit WASM memory usage. Application type checking remains a separate `bun run check` command.

--- a/tests/depth-alpha.test.mjs
+++ b/tests/depth-alpha.test.mjs
@@ -1,0 +1,84 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+	MagickImage,
+	MagickReadSettings,
+	MagickFormat,
+} from "@imagemagick/magick-wasm";
+import { fixture, write, rgba, convert } from "./helpers-magick.mjs";
+const source = fixture();
+const png16 = write(source, MagickFormat.Png48);
+source.dispose();
+
+for (const to of [
+	".png",
+	".tiff",
+	".tif",
+	".jxl",
+	".jp2",
+	".psd",
+	".ppm",
+	".webp",
+])
+	test(`16-bit PNG → ${to} uses actual Q8 precision and preserves decoded pixels`, async () => {
+		const input = MagickImage.create(png16);
+		const output = MagickImage.create(await convert(png16, to, true, 100));
+		try {
+			assert.equal(input.depth, 16);
+			assert.equal(output.depth, 8);
+			assert.deepEqual(rgba(output), rgba(input));
+		} finally {
+			input.dispose();
+			output.dispose();
+		}
+	});
+
+for (const to of [".tiff", ".tif", ".psd", ".png", ".jxl"])
+	test(`palette PNG → ${to} preserves semi-transparent alpha instead of using palette index depth`, async () => {
+		const src = fixture(true);
+		const png = write(src, MagickFormat.Png);
+		src.dispose();
+		const input = MagickImage.create(png);
+		const output = MagickImage.create(await convert(png, to, false, 100));
+		try {
+			assert.ok(
+				input.depth < 8,
+				"Fixture must have a low-bit palette index",
+			);
+			assert.deepEqual(rgba(output), rgba(input));
+		} finally {
+			input.dispose();
+			output.dispose();
+		}
+	});
+
+for (const to of [".tiff", ".psd", ".ppm", ".jp2"])
+	test(`palette PNG → ${to} preserves 8-bit RGB values that are not palette indices`, async () => {
+		const colors = [
+			[28, 99, 157, 255],
+			[121, 188, 33, 255],
+			[94, 77, 14, 255],
+		];
+		const pixels = Uint8Array.from(
+			Array.from({ length: 48 * 32 }, (_, i) => colors[i % 3]).flat(),
+		);
+		const src = MagickImage.create(
+			pixels,
+			new MagickReadSettings({
+				format: MagickFormat.Rgba,
+				width: 48,
+				height: 32,
+			}),
+		);
+		const png = write(src, MagickFormat.Png);
+		src.dispose();
+		const input = MagickImage.create(png);
+		const output = MagickImage.create(await convert(png, to, true, 100));
+		try {
+			assert.ok(input.depth < 8);
+			assert.deepEqual(rgba(output), pixels);
+		} finally {
+			input.dispose();
+			output.dispose();
+		}
+	});

--- a/tests/helpers-load-ts.mjs
+++ b/tests/helpers-load-ts.mjs
@@ -1,0 +1,19 @@
+import { readFile } from "node:fs/promises";
+import ts from "typescript";
+export async function moduleUrl(url) {
+	const { outputText } = ts.transpileModule(await readFile(url, "utf8"), {
+		compilerOptions: {
+			module: ts.ModuleKind.ESNext,
+			target: ts.ScriptTarget.ES2022,
+		},
+	});
+	let source = outputText;
+	for (const match of outputText.matchAll(/from "([^"]+)"/g)) {
+		const name = match[1];
+		const target = name.startsWith(".")
+			? await moduleUrl(new URL(name + ".ts", url))
+			: import.meta.resolve(name);
+		source = source.replace(JSON.stringify(name), JSON.stringify(target));
+	}
+	return `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`;
+}

--- a/tests/helpers-magick.mjs
+++ b/tests/helpers-magick.mjs
@@ -1,0 +1,60 @@
+import { readFile } from "node:fs/promises";
+import {
+	initializeImageMagick,
+	MagickImage,
+	MagickReadSettings,
+	MagickFormat,
+} from "@imagemagick/magick-wasm";
+import { moduleUrl } from "./helpers-load-ts.mjs";
+
+const { magickConvert } = await import(
+	await moduleUrl(
+		new URL("../src/lib/util/magick-convert.ts", import.meta.url),
+	)
+);
+await initializeImageMagick(
+	await readFile(
+		new URL(import.meta.resolve("@imagemagick/magick-wasm/magick.wasm")),
+	),
+);
+
+export const write = (image, format) =>
+	image.write(format, (bytes) => new Uint8Array(bytes));
+export const rgba = (image) =>
+	image.getPixels(
+		(pixels) =>
+			new Uint8Array(
+				pixels.toByteArray(0, 0, image.width, image.height, "RGBA"),
+			),
+	);
+
+// Synthetic RGB gradient, or three transparent/semitransparent/opaque bands.
+export function fixture(alpha = false) {
+	const width = 48,
+		height = 32;
+	const pixels = new Uint8Array(width * height * 4);
+	for (let y = 0; y < height; y++) {
+		for (let x = 0; x < width; x++) {
+			pixels.set(
+				alpha
+					? [255, 0, 0, x < 16 ? 0 : x < 32 ? 128 : 255]
+					: [x * 5, y * 7, (x * 13 + y * 3) % 256, 255],
+				(y * width + x) * 4,
+			);
+		}
+	}
+	return MagickImage.create(
+		pixels,
+		new MagickReadSettings({ format: MagickFormat.Rgba, width, height }),
+	);
+}
+
+// Exercise the same function the conversion worker calls, with real WASM codecs.
+export async function convert(bytes, to, keepMetadata = false, quality = 100) {
+	const input = MagickImage.create(bytes);
+	try {
+		return await magickConvert(input, to, keepMetadata, quality);
+	} finally {
+		input.dispose();
+	}
+}

--- a/tests/magick-convert.test.mjs
+++ b/tests/magick-convert.test.mjs
@@ -1,0 +1,73 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+	MagickImage,
+	MagickFormat,
+	MagickReadSettings,
+} from "@imagemagick/magick-wasm";
+import { fixture, write, rgba, convert } from "./helpers-magick.mjs";
+
+test("PNG conversion preserves decoded dimensions and pixels", async () => {
+	const source = fixture();
+	let output;
+	try {
+		output = MagickImage.create(
+			await convert(write(source, MagickFormat.Png), ".png"),
+		);
+		assert.deepEqual(
+			[output.width, output.height],
+			[source.width, source.height],
+		);
+		assert.deepEqual(rgba(output), rgba(source));
+	} finally {
+		output?.dispose();
+		source.dispose();
+	}
+});
+
+for (const keep of [false, true]) {
+	test(`PNG comment follows keepMetadata=${keep}`, async () => {
+		const source = fixture();
+		let output;
+		try {
+			source.setAttribute("comment", "synthetic-test");
+			output = MagickImage.create(
+				await convert(write(source, MagickFormat.Png), ".png", keep),
+			);
+			assert.equal(
+				output.getAttribute("comment"),
+				keep ? "synthetic-test" : null,
+			);
+		} finally {
+			output?.dispose();
+			source.dispose();
+		}
+	});
+}
+
+test("ICO conversion keeps its 256-pixel size limit and aspect ratio", async () => {
+	const source = fixture();
+	let output;
+	try {
+		source.resize(600, 400);
+		output = MagickImage.create(
+			await convert(write(source, MagickFormat.Png), ".ico"),
+			new MagickReadSettings({ format: MagickFormat.Ico }),
+		);
+		assert.deepEqual([output.width, output.height], [256, 171]);
+	} finally {
+		output?.dispose();
+		source.dispose();
+	}
+});
+
+test("encoder failures reject the conversion promise", async () => {
+	const source = fixture();
+	try {
+		await assert.rejects(
+			convert(write(source, MagickFormat.Png), ".invalid-format"),
+		);
+	} finally {
+		source.dispose();
+	}
+});

--- a/tests/tiff-packed-depth.test.mjs
+++ b/tests/tiff-packed-depth.test.mjs
@@ -1,0 +1,49 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+	MagickFormat,
+	MagickImage,
+	MagickReadSettings,
+} from "@imagemagick/magick-wasm";
+import { write, rgba, convert } from "./helpers-magick.mjs";
+
+for (const depth of [1, 2, 4]) {
+	for (const to of [".tiff", ".tif"]) {
+		test(`${depth}-bit grayscale keeps packed TIFF samples for ${to}`, async () => {
+			const width = 256,
+				height = 128,
+				levels = 2 ** depth;
+			const pixels = new Uint8Array(width * height * 4);
+			for (let i = 0; i < width * height; i++) {
+				const value = ((i % levels) * 255) / (levels - 1);
+				pixels.set([value, value, value, 255], i * 4);
+			}
+			const source = MagickImage.create(
+				pixels,
+				new MagickReadSettings({
+					format: MagickFormat.Rgba,
+					width,
+					height,
+				}),
+			);
+			let input, output;
+			try {
+				source.depth = depth;
+				const png = write(source, MagickFormat.Png);
+				input = MagickImage.create(png);
+				assert.equal(input.depth, depth);
+				output = MagickImage.create(await convert(png, to, false, 100));
+				assert.equal(
+					output.depth,
+					depth,
+					"Do not expand valid packed samples to 8 bits",
+				);
+				assert.deepEqual(rgba(output), rgba(input));
+			} finally {
+				output?.dispose();
+				input?.dispose();
+				source.dispose();
+			}
+		});
+	}
+}


### PR DESCRIPTION
The Q8 WASM engine can retain a 16-bit input depth tag even though its decoded channels are 8-bit. Writing that tag back produces unnecessarily high-depth output without recovering precision. Conversely, a low-bit palette PNG reports its index depth, which does not describe the precision of its RGB/alpha channels: a semi-transparent alpha value of 128 can become 85 in TIFF output. Indexed PNGs with transparency can also produce an unreadable PSD.

Bound output depth by `Quantum.depth`, with an 8-bit minimum for decoded channel values except valid packed TIFF samples, and expand indexed-alpha images to true-color alpha when writing PSD. The upper bound follows the engine's Quantum depth instead of hard-coding Q8. For low-depth TIFF/TIF output, inspect the actual channel precision before promoting the source depth. Valid 1/2/4-bit gray samples remain packed; palette colors and semi-transparent alpha that need 8 bits are still promoted. The precision scan only runs when writing TIFF from an image reporting fewer than 8 bits.

## Validation

Real WASM round trips cover 16-bit-tagged PNG, low-bit indexed alpha and nontrivial palette colors across PNG, TIFF/TIF, JXL, JP2, PSD, PPM and WebP as applicable. Additional grayscale tests check 1/2/4-bit packed samples through both TIFF extensions. Pixel assertions compare against decoded Q8 inputs, not the original file's full 16-bit precision. AVIF's separate encoder compatibility fix is not required by this branch's tests.

- `bun run test`: **28 passed**, including five shared behavior tests.
- The defect-focused tests fail against the unchanged upstream conversion function (**12 failing tests** before this fix).
- `bun run build`: passed with a local `.env` based on `.env.example`.
- ESLint and Prettier: changed files pass.
- `bun run check`: the same **7 pre-existing missing Node type errors** as upstream; no additional errors. Full-repository lint has existing failures outside this change; changed files pass.

## Patch structure

This branch is based on upstream `cc7b5a54d5e9c797b377db47b9bdfbb561707783` and includes shared test harness commit `c69e961`, which moves the existing `magickConvert` function unchanged into a utility imported by the worker. Tests invoke that exact production function with the installed WASM. No new package dependency is introduced.

Each repair branch can be reviewed independently. After the shared harness lands, the remaining branches will need rebasing onto upstream main to resolve overlapping edits in `magick-convert.ts`.

Shares the behavior-preserving test harness with https://github.com/VERT-sh/VERT/pull/275.
