### PR TITLE
fix: enable lossless AVIF encoding at quality 100

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"format": "prettier --write .",
-		"lint": "prettier --check . && eslint ."
+		"lint": "prettier --check . && eslint .",
+		"test": "node --test --test-concurrency=1 tests/*.test.mjs"
 	},
 	"devDependencies": {
 		"@inlang/paraglide-js": "^2.5.0",

--- a/src/lib/util/magick-avif.ts
+++ b/src/lib/util/magick-avif.ts
@@ -1,0 +1,34 @@
+import {
+	ColorSpace,
+	Quantum,
+	type IMagickImage,
+} from "@imagemagick/magick-wasm";
+
+/** Keep AVIF quality 100 lossless without libheif's incompatible AOM IQ tune. */
+export function configureAvifOutput(image: IMagickImage): void {
+	// Q8 WASM may retain a 16-bit PNG's depth tag after decoding to 8-bit
+	// pixels. Passing that tag to libheif expands the output to 12-bit AV1,
+	// increasing size without restoring any precision. Respect the actual
+	// engine precision (and preserve higher precision in a future Q16 build).
+	image.depth = Math.min(image.depth, Quantum.depth);
+	if (image.quality < 100) return;
+
+	// An identity matrix stores RGB/GBR without chroma subsampling and makes
+	// libheif choose SSIM instead of IQ (IQ enables delta-q, forbidden losslessly).
+	// Keep source primaries/transfer, or defer to its ICC profile when present.
+	let primaries = "2";
+	let transfer = "2";
+	if (!image.getColorProfile()) {
+		const cicp = image
+			.getAttribute("heic:cicp")
+			?.match(/^(\d+)\/(\d+)\/\d+\/[01]$/);
+		if (cicp) {
+			[, primaries, transfer] = cicp;
+		} else if (image.colorSpace === ColorSpace.sRGB) {
+			primaries = "1";
+			transfer = "13";
+		}
+	}
+	image.settings.setDefine("heic:chroma", "444");
+	image.settings.setDefine("heic:cicp", `${primaries}/${transfer}/0/1`);
+}

--- a/src/lib/util/magick-convert.ts
+++ b/src/lib/util/magick-convert.ts
@@ -1,0 +1,42 @@
+import { MagickFormat, type IMagickImage } from "@imagemagick/magick-wasm";
+
+export const magickConvert = async (
+	img: IMagickImage,
+	to: string,
+	keepMetadata: boolean,
+	compression?: number,
+) => {
+	let fmt = to.slice(1).toUpperCase();
+	if (fmt === "JFIF") fmt = "JPEG";
+
+	// ICO size clamp to avoid WidthOrHeightExceedsLimit
+	if (fmt === "ICO") {
+		const max = 256;
+		const w = img.width;
+		const h = img.height;
+
+		if (w > max || h > max) {
+			const scale = max / Math.max(w, h);
+			const newW = Math.max(1, Math.round(w * scale));
+			const newH = Math.max(1, Math.round(h * scale));
+
+			img.resize(newW, newH);
+		}
+	}
+
+	const result = await new Promise<Uint8Array>((resolve, reject) => {
+		try {
+			// magick-wasm automatically clamps (https://github.com/dlemstra/magick-wasm/blob/76fc6f2b0c0497d2ddc251bbf6174b4dc92ac3ea/src/magick-image.ts#L2480)
+			if (compression) img.quality = compression;
+			if (!keepMetadata) img.strip();
+
+			img.write(fmt as unknown as MagickFormat, (o: Uint8Array) => {
+				resolve(structuredClone(o));
+			});
+		} catch (error) {
+			reject(error);
+		}
+	});
+
+	return result;
+};

--- a/src/lib/util/magick-convert.ts
+++ b/src/lib/util/magick-convert.ts
@@ -1,4 +1,5 @@
 import { MagickFormat, type IMagickImage } from "@imagemagick/magick-wasm";
+import { configureAvifOutput } from "./magick-avif";
 
 export const magickConvert = async (
 	img: IMagickImage,
@@ -29,6 +30,8 @@ export const magickConvert = async (
 			// magick-wasm automatically clamps (https://github.com/dlemstra/magick-wasm/blob/76fc6f2b0c0497d2ddc251bbf6174b4dc92ac3ea/src/magick-image.ts#L2480)
 			if (compression) img.quality = compression;
 			if (!keepMetadata) img.strip();
+
+			if (fmt === "AVIF") configureAvifOutput(img);
 
 			img.write(fmt as unknown as MagickFormat, (o: Uint8Array) => {
 				resolve(structuredClone(o));

--- a/src/lib/workers/magick.ts
+++ b/src/lib/workers/magick.ts
@@ -4,8 +4,8 @@ import {
 	MagickImage,
 	MagickImageCollection,
 	MagickReadSettings,
-	type IMagickImage,
 } from "@imagemagick/magick-wasm";
+import { magickConvert } from "$lib/util/magick-convert";
 import { makeZip } from "client-zip";
 import { parseAni } from "$lib/util/parse/ani";
 import { parseIcns } from "vert-wasm";
@@ -282,47 +282,6 @@ const readToEnd = async (reader: ReadableStreamDefaultReader<Uint8Array>) => {
 	);
 	const arrayBuffer = await blob.arrayBuffer();
 	return new Uint8Array(arrayBuffer);
-};
-
-const magickConvert = async (
-	img: IMagickImage,
-	to: string,
-	keepMetadata: boolean,
-	compression?: number,
-) => {
-	let fmt = to.slice(1).toUpperCase();
-	if (fmt === "JFIF") fmt = "JPEG";
-
-	// ICO size clamp to avoid WidthOrHeightExceedsLimit
-	if (fmt === "ICO") {
-		const max = 256;
-		const w = img.width;
-		const h = img.height;
-
-		if (w > max || h > max) {
-			const scale = max / Math.max(w, h);
-			const newW = Math.max(1, Math.round(w * scale));
-			const newH = Math.max(1, Math.round(h * scale));
-
-			img.resize(newW, newH);
-		}
-	}
-
-	const result = await new Promise<Uint8Array>((resolve, reject) => {
-		try {
-			// magick-wasm automatically clamps (https://github.com/dlemstra/magick-wasm/blob/76fc6f2b0c0497d2ddc251bbf6174b4dc92ac3ea/src/magick-image.ts#L2480)
-			if (compression) img.quality = compression;
-			if (!keepMetadata) img.strip();
-
-			img.write(fmt as unknown as MagickFormat, (o: Uint8Array) => {
-				resolve(structuredClone(o));
-			});
-		} catch (error) {
-			reject(error);
-		}
-	});
-
-	return result;
 };
 
 onmessage = async (e) => {

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,7 @@
+# Image conversion regression tests
+
+Run `bun install --frozen-lockfile`, then `bun run test` (Node.js 20+).
+
+These tests initialize the installed ImageMagick WASM module and invoke the same `magickConvert` function used by the worker. Fixtures are generated in memory. Encoded outputs are decoded again to inspect dimensions, pixels and metadata; no network service or user images are required.
+
+`helpers-load-ts.mjs` transpiles the small TypeScript utility and its relative imports using the existing TypeScript dependency. The test command runs files sequentially to limit WASM memory usage. Application type checking remains a separate `bun run check` command.

--- a/tests/avif-lossless.test.mjs
+++ b/tests/avif-lossless.test.mjs
@@ -1,0 +1,132 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { MagickImage, MagickFormat, ColorType } from "@imagemagick/magick-wasm";
+import { fixture, write, rgba, convert } from "./helpers-magick.mjs";
+import { moduleUrl } from "./helpers-load-ts.mjs";
+
+const { magickConvert } = await import(
+	await moduleUrl(
+		new URL("../src/lib/util/magick-convert.ts", import.meta.url),
+	)
+);
+
+for (const from of [MagickFormat.Png, MagickFormat.WebP]) {
+	for (const alpha of [false, true]) {
+		test(`${from} ${alpha ? "RGBA" : "RGB"} converts to odd-sized AVIF at quality 100 without pixel loss`, async () => {
+			const source = fixture(alpha);
+			source.resize(17, 13);
+			let input, output;
+			try {
+				// Use full channel depth so this test is independent of palette-depth fixes.
+				source.colorType = alpha
+					? ColorType.TrueColorAlpha
+					: ColorType.TrueColor;
+				source.quality = 100;
+				const bytes = write(
+					source,
+					from === MagickFormat.Png ? MagickFormat.Png32 : from,
+				);
+				input = MagickImage.create(bytes);
+				assert.equal(input.width % 2, 1);
+				assert.equal(input.height % 2, 1);
+				output = MagickImage.create(
+					await convert(bytes, ".avif", true, 100),
+				);
+				assert.deepEqual(
+					[output.width, output.height],
+					[input.width, input.height],
+				);
+				assert.deepEqual(rgba(output), rgba(input));
+			} finally {
+				output?.dispose();
+				input?.dispose();
+				source.dispose();
+			}
+		});
+	}
+}
+
+test("lossy AVIF retains its requested quality and encoder defaults", async () => {
+	const image = fixture();
+	try {
+		const output = await magickConvert(image, ".avif", true, 80);
+		assert.ok(output.length > 0);
+		assert.equal(image.quality, 80);
+		assert.equal(image.settings.getDefine("heic:cicp"), null);
+		assert.equal(image.settings.getDefine("heic:chroma"), null);
+	} finally {
+		image.dispose();
+	}
+});
+
+test("lossless AVIF keeps source CICP primaries and transfer characteristics", async () => {
+	const image = fixture();
+	let output;
+	try {
+		image.setAttribute("heic:cicp", "9/16/9/0");
+		output = MagickImage.create(
+			await magickConvert(image, ".avif", true, 100),
+		);
+		assert.equal(image.quality, 100);
+		assert.equal(output.getAttribute("heic:cicp"), "9/16/0/1");
+		assert.deepEqual(rgba(output), rgba(image));
+	} finally {
+		output?.dispose();
+		image.dispose();
+	}
+});
+
+for (const keep of [true, false]) {
+	test(`lossless AVIF follows keepMetadata=${keep} for ICC and comments`, async () => {
+		// Reuse the existing upstream avatar only as a source of a valid ICC profile.
+		const profileSource = MagickImage.create(
+			await readFile(
+				new URL("../src/lib/assets/avatars/liam.jpg", import.meta.url),
+			),
+		);
+		const profile = profileSource.getColorProfile();
+		profileSource.dispose();
+		assert.ok(profile);
+		const image = fixture();
+		let output;
+		try {
+			image.setProfile(profile);
+			image.setAttribute("comment", "synthetic-test");
+			output = MagickImage.create(
+				await magickConvert(image, ".avif", keep, 100),
+			);
+			if (keep) {
+				assert.deepEqual(output.getColorProfile()?.data, profile.data);
+				assert.equal(image.settings.getDefine("heic:cicp"), "2/2/0/1");
+			} else {
+				assert.equal(output.getColorProfile(), null);
+				assert.equal(output.getAttribute("comment"), null);
+			}
+		} finally {
+			output?.dispose();
+			image.dispose();
+		}
+	});
+}
+
+for (const quality of [60, 100]) {
+	test(`16-bit source tags do not inflate Q8 AVIF output depth at quality ${quality}`, async () => {
+		const source = fixture();
+		let input, output;
+		try {
+			const bytes = write(source, MagickFormat.Png48);
+			input = MagickImage.create(bytes);
+			assert.equal(input.depth, 16);
+			output = MagickImage.create(
+				await convert(bytes, ".avif", true, quality),
+			);
+			assert.equal(output.depth, 8);
+			if (quality === 100) assert.deepEqual(rgba(output), rgba(input));
+		} finally {
+			output?.dispose();
+			input?.dispose();
+			source.dispose();
+		}
+	});
+}

--- a/tests/avif-lossless.test.mjs
+++ b/tests/avif-lossless.test.mjs
@@ -1,7 +1,12 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
-import { MagickImage, MagickFormat, ColorType } from "@imagemagick/magick-wasm";
+import {
+	MagickImage,
+	MagickFormat,
+	ColorType,
+	ColorProfile,
+} from "@imagemagick/magick-wasm";
 import { fixture, write, rgba, convert } from "./helpers-magick.mjs";
 import { moduleUrl } from "./helpers-load-ts.mjs";
 
@@ -85,9 +90,11 @@ for (const keep of [true, false]) {
 				new URL("../src/lib/assets/avatars/liam.jpg", import.meta.url),
 			),
 		);
-		const profile = profileSource.getColorProfile();
+		const profileData = profileSource.getColorProfile()?.data;
+		assert.ok(profileData);
+		// Profile views may refer to WASM memory owned by the source image.
+		const profile = new ColorProfile(new Uint8Array(profileData));
 		profileSource.dispose();
-		assert.ok(profile);
 		const image = fixture();
 		let output;
 		try {

--- a/tests/helpers-load-ts.mjs
+++ b/tests/helpers-load-ts.mjs
@@ -1,0 +1,19 @@
+import { readFile } from "node:fs/promises";
+import ts from "typescript";
+export async function moduleUrl(url) {
+	const { outputText } = ts.transpileModule(await readFile(url, "utf8"), {
+		compilerOptions: {
+			module: ts.ModuleKind.ESNext,
+			target: ts.ScriptTarget.ES2022,
+		},
+	});
+	let source = outputText;
+	for (const match of outputText.matchAll(/from "([^"]+)"/g)) {
+		const name = match[1];
+		const target = name.startsWith(".")
+			? await moduleUrl(new URL(name + ".ts", url))
+			: import.meta.resolve(name);
+		source = source.replace(JSON.stringify(name), JSON.stringify(target));
+	}
+	return `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`;
+}

--- a/tests/helpers-magick.mjs
+++ b/tests/helpers-magick.mjs
@@ -1,0 +1,60 @@
+import { readFile } from "node:fs/promises";
+import {
+	initializeImageMagick,
+	MagickImage,
+	MagickReadSettings,
+	MagickFormat,
+} from "@imagemagick/magick-wasm";
+import { moduleUrl } from "./helpers-load-ts.mjs";
+
+const { magickConvert } = await import(
+	await moduleUrl(
+		new URL("../src/lib/util/magick-convert.ts", import.meta.url),
+	)
+);
+await initializeImageMagick(
+	await readFile(
+		new URL(import.meta.resolve("@imagemagick/magick-wasm/magick.wasm")),
+	),
+);
+
+export const write = (image, format) =>
+	image.write(format, (bytes) => new Uint8Array(bytes));
+export const rgba = (image) =>
+	image.getPixels(
+		(pixels) =>
+			new Uint8Array(
+				pixels.toByteArray(0, 0, image.width, image.height, "RGBA"),
+			),
+	);
+
+// Synthetic RGB gradient, or three transparent/semitransparent/opaque bands.
+export function fixture(alpha = false) {
+	const width = 48,
+		height = 32;
+	const pixels = new Uint8Array(width * height * 4);
+	for (let y = 0; y < height; y++) {
+		for (let x = 0; x < width; x++) {
+			pixels.set(
+				alpha
+					? [255, 0, 0, x < 16 ? 0 : x < 32 ? 128 : 255]
+					: [x * 5, y * 7, (x * 13 + y * 3) % 256, 255],
+				(y * width + x) * 4,
+			);
+		}
+	}
+	return MagickImage.create(
+		pixels,
+		new MagickReadSettings({ format: MagickFormat.Rgba, width, height }),
+	);
+}
+
+// Exercise the same function the conversion worker calls, with real WASM codecs.
+export async function convert(bytes, to, keepMetadata = false, quality = 100) {
+	const input = MagickImage.create(bytes);
+	try {
+		return await magickConvert(input, to, keepMetadata, quality);
+	} finally {
+		input.dispose();
+	}
+}

--- a/tests/magick-convert.test.mjs
+++ b/tests/magick-convert.test.mjs
@@ -1,0 +1,73 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+	MagickImage,
+	MagickFormat,
+	MagickReadSettings,
+} from "@imagemagick/magick-wasm";
+import { fixture, write, rgba, convert } from "./helpers-magick.mjs";
+
+test("PNG conversion preserves decoded dimensions and pixels", async () => {
+	const source = fixture();
+	let output;
+	try {
+		output = MagickImage.create(
+			await convert(write(source, MagickFormat.Png), ".png"),
+		);
+		assert.deepEqual(
+			[output.width, output.height],
+			[source.width, source.height],
+		);
+		assert.deepEqual(rgba(output), rgba(source));
+	} finally {
+		output?.dispose();
+		source.dispose();
+	}
+});
+
+for (const keep of [false, true]) {
+	test(`PNG comment follows keepMetadata=${keep}`, async () => {
+		const source = fixture();
+		let output;
+		try {
+			source.setAttribute("comment", "synthetic-test");
+			output = MagickImage.create(
+				await convert(write(source, MagickFormat.Png), ".png", keep),
+			);
+			assert.equal(
+				output.getAttribute("comment"),
+				keep ? "synthetic-test" : null,
+			);
+		} finally {
+			output?.dispose();
+			source.dispose();
+		}
+	});
+}
+
+test("ICO conversion keeps its 256-pixel size limit and aspect ratio", async () => {
+	const source = fixture();
+	let output;
+	try {
+		source.resize(600, 400);
+		output = MagickImage.create(
+			await convert(write(source, MagickFormat.Png), ".ico"),
+			new MagickReadSettings({ format: MagickFormat.Ico }),
+		);
+		assert.deepEqual([output.width, output.height], [256, 171]);
+	} finally {
+		output?.dispose();
+		source.dispose();
+	}
+});
+
+test("encoder failures reject the conversion promise", async () => {
+	const source = fixture();
+	try {
+		await assert.rejects(
+			convert(write(source, MagickFormat.Png), ".invalid-format"),
+		);
+	} finally {
+		source.dispose();
+	}
+});


### PR DESCRIPTION
PNG/WebP to AVIF at quality 100 fails with the installed `@imagemagick/magick-wasm@0.0.43`:

```text
Only --enable_chroma_deltaq=0 can be used with --lossless=1.
```

Configure 4:4:4 sampling and a full-range identity RGB/GBR matrix for lossless AVIF. This selects a compatible libheif/AOM path and avoids a lossy RGB-to-YUV transform. Preserve source CICP primaries/transfer or defer to an embedded ICC profile. The requested quality stays 100; lossy quality settings keep their existing chroma/CICP defaults.

Also cap AVIF input depth at the engine's actual quantum precision. A Q8 decode of a 16-bit-tagged PNG should not be expanded into a 12-bit AVIF with no additional precision.

References: [ImageMagick defines](https://imagemagick.org/defines/), [ImageMagick HEIC writer](https://github.com/ImageMagick/ImageMagick/blob/7.1.2-30/coders/heic.c), [libheif AOM encoder](https://github.com/strukturag/libheif/blob/master/libheif/plugins/encoder_aom.cc). The executable regression evidence uses the installed 0.0.43 WASM; the libheif link is a moving source reference.

## Validation

Tests cover odd-sized PNG/WebP RGB and RGBA inputs, exact decoded pixels at quality 100, quality 80 defaults, CICP values, ICC retention/removal, and output depth at quality 60/100. Lossless refers to decoded Q8 pixels. This is an AVIF encoding fix; it does not claim to resolve HEIC/AVIF decoding errors. It does not change the default quality or promise AVIF will always be smaller than WebP.

- `bun run test`: **15 passed**, including five shared behavior tests.
- The defect-focused tests fail against the unchanged upstream conversion function (**9 failing tests** before this fix).
- `bun run build`: passed with a local `.env` based on `.env.example`.
- ESLint and Prettier: changed files pass.
- `bun run check`: the same **7 pre-existing missing Node type errors** as upstream; no additional errors. Full-repository lint has existing failures outside this change; changed files pass.

## Patch structure

This branch is based on upstream `cc7b5a54d5e9c797b377db47b9bdfbb561707783` and includes shared test harness commit `c69e961`, which moves the existing `magickConvert` function unchanged into a utility imported by the worker. Tests invoke that exact production function with the installed WASM. No new package dependency is introduced.

Each repair branch can be reviewed independently. After the shared harness lands, the remaining branches will need rebasing onto upstream main to resolve overlapping edits in `magick-convert.ts`.

Shares the behavior-preserving test harness with https://github.com/VERT-sh/VERT/pull/275.
